### PR TITLE
Fix map name parsing and run build

### DIFF
--- a/src/js/modules/buildManagement.js
+++ b/src/js/modules/buildManagement.js
@@ -324,9 +324,16 @@ export async function updateCurrentBuild(buildId) {
 
   // 🗺 Map name update (if selected)
   if (mapImage?.src) {
-    const match = mapImage.src.match(/\/img\/maps\/(.+)\.webp/);
-    if (match) {
-      updatedData.map = match[1].replace(/_/g, " ");
+    try {
+      const url = new URL(mapImage.src);
+      const filename = url.pathname.split("/").pop();
+      if (filename) {
+        updatedData.map = filename
+          .replace(/\.webp$/i, "")
+          .replace(/_/g, " ");
+      }
+    } catch (err) {
+      console.warn("🛑 Failed to parse map name:", mapImage.src, err);
     }
   }
 


### PR DESCRIPTION
## Summary
- improve map name parsing when updating a build
- install dependencies
- run Vite build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840224612d8832a9786fdf16aa41977