### PR TITLE
keywords - add flask replay parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,16 @@ can toggle this in **Settings**:
 * Install Firebase CLI (`npm install -g firebase-tools` or `npx firebase login`).
 * Use `npm run build` followed by `firebase hosting:channel:deploy dev` for preview deployments.
 
+## Replay Parsing Backend
+
+To parse StarCraft II replays locally you must run the Python service:
+
+```bash
+pip install flask flask-cors sc2reader
+python app.py
+```
+
+The server listens on http://localhost:5000. The frontend will send uploaded
+replays to `/upload` on that server and populate the **Build Order** text area
+with the parsed results.
+

--- a/app.py
+++ b/app.py
@@ -32,7 +32,8 @@ def upload():
     for event in replay.events:
         if isinstance(event, sc2reader.events.tracker.UnitBornEvent) and event.control_pid == player.pid:
             supply = int(player.current_food_used.get(event.second, 0))
-            build_lines.append(f'[{supply}] {event.unit_type_name}')
+            if event.unit_type_name and 'Beacon' not in event.unit_type_name:
+                build_lines.append(f'[{supply}] {event.unit_type_name}')
 
     return '\n'.join(build_lines)
 

--- a/app.py
+++ b/app.py
@@ -33,15 +33,17 @@ def upload():
             return 'No player found in replay', 400
 
         build_lines = []
+
         for event in replay.events:
-            if isinstance(event, sc2reader.events.tracker.UnitBornEvent) and event.control_pid == player.pid:
-                try:
-                    supply = int(player.current_food_used.get(event.second, 0))
-                    unit_name = event.unit_type_name or ""
-                    if "Beacon" not in unit_name:
-                        build_lines.append(f'[{supply}] {unit_name}')
-                except Exception as inner_error:
-                    print(f"⚠️ Skipped event due to error: {inner_error}")
+            if isinstance(event, sc2reader.events.tracker.UnitBornEvent):
+                actor = next((p for p in replay.players if p.pid == event.control_pid), None)
+                if actor and hasattr(actor, "current_food_used"):
+                    try:
+                        supply = int(actor.current_food_used.get(event.second, 0))
+                        if event.unit_type_name and 'Beacon' not in event.unit_type_name:
+                            build_lines.append(f'[{supply}] {event.unit_type_name}')
+                    except Exception as inner_error:
+                        print(f"⚠️ Skipped event due to error: {inner_error}")
 
         return '\n'.join(build_lines)
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,40 @@
+from flask import Flask, request
+from flask_cors import CORS
+import sc2reader
+from sc2reader.engine.plugins import SupplyTracker
+import io
+
+app = Flask(__name__)
+CORS(app)
+
+sc2reader.engine.register_plugin(SupplyTracker())
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    if 'replay' not in request.files:
+        return 'No replay uploaded', 400
+    file = request.files['replay']
+    if file.filename == '':
+        return 'No replay uploaded', 400
+
+    # Read into BytesIO for sc2reader
+    replay_data = io.BytesIO(file.read())
+    try:
+        replay = sc2reader.load_replay(replay_data, load_map=True)
+    except Exception as e:
+        return f'Failed to load replay: {e}', 400
+
+    player = next((p for p in replay.players if not p.is_observer), None)
+    if player is None:
+        return 'No player found in replay', 400
+
+    build_lines = []
+    for event in replay.events:
+        if isinstance(event, sc2reader.events.tracker.UnitBornEvent) and event.control_pid == player.pid:
+            supply = int(player.current_food_used.get(event.second, 0))
+            build_lines.append(f'[{supply}] {event.unit_type_name}')
+
+    return '\n'.join(build_lines)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/app.py
+++ b/app.py
@@ -14,28 +14,40 @@ def index():
 def upload():
     if 'replay' not in request.files:
         return 'No replay uploaded', 400
+
     file = request.files['replay']
     if file.filename == '':
         return 'No replay uploaded', 400
 
+    # Read replay into memory
     replay_data = io.BytesIO(file.read())
     try:
         replay = sc2reader.load_replay(replay_data, load_map=True)
     except Exception as e:
+        print("❌ Failed to load replay:", e)
         return f'Failed to load replay: {e}', 400
 
-    player = next((p for p in replay.players if not p.is_observer), None)
-    if player is None:
-        return 'No player found in replay', 400
+    try:
+        player = next((p for p in replay.players if not p.is_observer), None)
+        if player is None:
+            return 'No player found in replay', 400
 
-    build_lines = []
-    for event in replay.events:
-        if isinstance(event, sc2reader.events.tracker.UnitBornEvent) and event.control_pid == player.pid:
-            supply = int(player.current_food_used.get(event.second, 0))
-            if event.unit_type_name and 'Beacon' not in event.unit_type_name:
-                build_lines.append(f'[{supply}] {event.unit_type_name}')
+        build_lines = []
+        for event in replay.events:
+            if isinstance(event, sc2reader.events.tracker.UnitBornEvent) and event.control_pid == player.pid:
+                try:
+                    supply = int(player.current_food_used.get(event.second, 0))
+                    unit_name = event.unit_type_name or ""
+                    if "Beacon" not in unit_name:
+                        build_lines.append(f'[{supply}] {unit_name}')
+                except Exception as inner_error:
+                    print(f"⚠️ Skipped event due to error: {inner_error}")
 
-    return '\n'.join(build_lines)
+        return '\n'.join(build_lines)
+
+    except Exception as e:
+        print("❌ Error while processing events:", e)
+        return f'Failed to parse replay: {e}', 500
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/app.py
+++ b/app.py
@@ -1,13 +1,14 @@
 from flask import Flask, request
 from flask_cors import CORS
 import sc2reader
-from sc2reader.engine.plugins import SupplyTracker
 import io
 
 app = Flask(__name__)
 CORS(app)
 
-sc2reader.engine.register_plugin(SupplyTracker())
+@app.route('/')
+def index():
+    return '🟢 SC2 Replay Parser is live!'
 
 @app.route('/upload', methods=['POST'])
 def upload():
@@ -17,7 +18,6 @@ def upload():
     if file.filename == '':
         return 'No replay uploaded', 400
 
-    # Read into BytesIO for sc2reader
     replay_data = io.BytesIO(file.read())
     try:
         replay = sc2reader.load_replay(replay_data, load_map=True)

--- a/index.html
+++ b/index.html
@@ -718,7 +718,7 @@
     <div class="footer-center" id="site-info">
       <p>Made by Zystem</p>
 
-      <p>Version 0.5.7029</p>
+      <p>Version 0.5.7030</p>
 
 
     </div>

--- a/index.html
+++ b/index.html
@@ -316,6 +316,10 @@
             <input type="url" id="replayLinkInput" placeholder="Paste Drop.sc replay URL here..." style="flex: 1;" />
 
           </div>
+          <div style="margin-bottom: 10px;">
+            <input type="file" id="replayFileInput" accept=".SC2Replay" style="display: none" />
+            <button id="parseReplayButton" class="btn">Parse Local Replay</button>
+          </div>
 
           <!-- Replay Link View Button (visible if replayUrl exists) -->
           <div id="replayViewWrapper" style="display: none;">
@@ -714,7 +718,7 @@
     <div class="footer-center" id="site-info">
       <p>Made by Zystem</p>
 
-      <p>Version 0.5.7028</p>
+      <p>Version 0.5.7029</p>
 
 
     </div>

--- a/index.html
+++ b/index.html
@@ -714,7 +714,7 @@
     <div class="footer-center" id="site-info">
       <p>Made by Zystem</p>
 
-      <p>Version 0.5.7027</p>
+      <p>Version 0.5.7028</p>
 
 
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+flask-cors
+sc2reader

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -443,6 +443,7 @@ export async function initializeIndexPage() {
       analyzeBuildOrder(text);
     } catch (err) {
       console.error("Replay upload failed", err);
+      alert("Could not parse the replay. Make sure the Python backend is running.");
     }
   });
   safeAdd("buildOrderTitleText", "click", () => toggleTitleInput(true));

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -423,6 +423,28 @@ export async function initializeIndexPage() {
 
   safeInput("templateSearchBar", (val) => searchTemplates(val));
   safeInput("videoInput", (val) => updateYouTubeEmbed(val));
+  safeAdd("parseReplayButton", "click", () => {
+    const input = document.getElementById("replayFileInput");
+    if (input) input.click();
+  });
+  safeAdd("replayFileInput", "change", async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append("replay", file);
+    try {
+      const res = await fetch("http://localhost:5000/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const text = await res.text();
+      const buildInput = document.getElementById("buildOrderInput");
+      if (buildInput) buildInput.value = text;
+      analyzeBuildOrder(text);
+    } catch (err) {
+      console.error("Replay upload failed", err);
+    }
+  });
   safeAdd("buildOrderTitleText", "click", () => toggleTitleInput(true));
   safeAdd("buildOrderTitleText", "focus", () => toggleTitleInput(true));
 

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -433,7 +433,7 @@ export async function initializeIndexPage() {
     const formData = new FormData();
     formData.append("replay", file);
     try {
-      const res = await fetch("http://localhost:5000/upload", {
+      const res = await fetch("https://z-build-order.onrender.com/upload", {
         method: "POST",
         body: formData,
       });
@@ -443,7 +443,9 @@ export async function initializeIndexPage() {
       analyzeBuildOrder(text);
     } catch (err) {
       console.error("Replay upload failed", err);
-      alert("Could not parse the replay. Make sure the Python backend is running.");
+      alert(
+        "Could not parse the replay. Make sure the Python backend is running."
+      );
     }
   });
   safeAdd("buildOrderTitleText", "click", () => toggleTitleInput(true));

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -427,17 +427,25 @@ export async function initializeIndexPage() {
     const input = document.getElementById("replayFileInput");
     if (input) input.click();
   });
+
   safeAdd("replayFileInput", "change", async (e) => {
     const file = e.target.files[0];
     if (!file) return;
+
+    const btn = document.getElementById("parseReplayButton");
+    btn.disabled = true;
+    btn.innerText = "⏳ Parsing...";
+
     const formData = new FormData();
     formData.append("replay", file);
+
     try {
       const res = await fetch("https://z-build-order.onrender.com/upload", {
         method: "POST",
         body: formData,
       });
       const text = await res.text();
+
       const buildInput = document.getElementById("buildOrderInput");
       if (buildInput) buildInput.value = text;
       analyzeBuildOrder(text);
@@ -447,7 +455,11 @@ export async function initializeIndexPage() {
         "Could not parse the replay. Make sure the Python backend is running."
       );
     }
+
+    btn.disabled = false;
+    btn.innerText = "Parse Local Replay";
   });
+
   safeAdd("buildOrderTitleText", "click", () => toggleTitleInput(true));
   safeAdd("buildOrderTitleText", "focus", () => toggleTitleInput(true));
 


### PR DESCRIPTION
## Summary
- create `app.py` for Flask-based SC2 replay parsing
- bump version number in `index.html`

## Testing
- `python -m py_compile app.py`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6842f059b9ec832a9b6dfa23b00a6901