### PR TITLE
Fix duplicate community builds when filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,7 +799,7 @@
         target="_blank">Discord</a>
     </div>
     <div class="footer-center" id="site-info">
-      <p>Version 0.5.7112</p>
+      <p>Version 0.5.7113</p>
 
     </div>
     <div class="footer-right" id="site-logo">

--- a/src/js/modules/community.js
+++ b/src/js/modules/community.js
@@ -778,7 +778,12 @@ export function filterCommunityBuilds(categoryOrSubcat = "all") {
 */
 function renderCommunityBuildBatch(builds) {
   const container = document.getElementById("communityBuildsContainer");
-  const nextBatch = builds;
+  const seenIds = new Set();
+  const nextBatch = builds.filter((b) => {
+    if (seenIds.has(b.id)) return false;
+    seenIds.add(b.id);
+    return true;
+  });
 
   nextBatch.forEach((build) => {
     if (container.querySelector(`.build-entry[data-id="${build.id}"]`)) {


### PR DESCRIPTION
## Summary
- dedupe community build entries before rendering
- bump version to 0.5.7113

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684962213388832abad893cff5b785e8