### PR TITLE
Update privacy modal for analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -788,7 +788,7 @@
         target="_blank">Discord</a>
     </div>
     <div class="footer-center" id="site-info">
-      <p>Version 0.5.7117</p>
+      <p>Version 0.5.7118</p>
     </div>
     <div class="footer-right" id="site-logo">
       <a href="https://www.twitch.tv/zystem" target="_blank">
@@ -797,7 +797,7 @@
     </div>
   
   <div id="cookieBanner" class="cookie-banner" style="display: none;">
-    <span>This site uses cookies for analytics. Learn more in our <a href="#" id="cookiePolicyLink">Privacy Policy</a>.</span>
+    <span>This site uses cookies for login and optional analytics. Learn more in our <a href="#" id="cookiePolicyLink">Privacy Policy</a>.</span>
     <button id="cookieAccept" class="cookie-btn">Accept</button>
     <button id="cookieDecline" class="cookie-btn">Decline</button>
   </div>
@@ -808,7 +808,7 @@
       <span class="close-modal" id="closePrivacyModal">×</span>
       <h3>Privacy & Legal Notice</h3>
 
-      <p><strong>Last updated:</strong> May 5, 2025</p>
+      <p><strong>Last updated:</strong> June 12, 2025</p>
 
       <p><strong>Z-Build Order</strong> is a personal tool designed for managing and sharing StarCraft II build orders.
         By using this tool, you agree to the terms outlined below:</p>
@@ -834,17 +834,20 @@
         Your builds are stored privately under your Firebase account unless you explicitly choose to publish them.
       </p>
 
-      <h4>3. Cookies and Local Storage</h4>
+      <h4>3. Cookies, Analytics and Local Storage</h4>
       <p>
-        This site uses <strong>Firebase Authentication</strong>, which may rely on cookies or local browser storage to
-        keep
-        you signed in and secure. These cookies are necessary for login and session management and are not used for
-        tracking
+        This site uses <strong>Firebase Authentication</strong>, which may rely on cookies or local browser storage to keep
+        you signed in and secure. These cookies are necessary for login and session management and are not used for tracking
         or advertising.
       </p>
       <p>
-        Additionally, <strong>local storage</strong> is used to save your build drafts and preferences locally on your
-        device.
+        If you accept cookies, <strong>Firebase Analytics</strong> will load and collect aggregated usage data such as page
+        views and button clicks. Declining cookies prevents analytics from running. Analytics information helps improve the
+        app and does not include personally identifying data.
+      </p>
+      <p>
+        <strong>Local storage</strong> is also used to remember your cookie choice, save build drafts and store other
+        settings on your device.
       </p>
 
       <h4>4. Data Sharing</h4>


### PR DESCRIPTION
## Summary
- clarify that cookies enable optional analytics
- add analytics details to privacy modal
- bump version to 0.5.7118

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a2a0e72e4832a8b455482f2a3c100