### PR TITLE
Disable duplicate title save and adjust highlight

### DIFF
--- a/index.html
+++ b/index.html
@@ -791,7 +791,7 @@
     </div>
     <div class="footer-center" id="site-info">
 
-      <p>Version 0.5.7133</p>
+      <p>Version 0.5.7134</p>
 
     </div>
     <div class="footer-right" id="site-logo">

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -354,17 +354,14 @@ body {
   0% {
     border-color: red;
     box-shadow: 0 0 10px red;
-    transform: scale(1);
   }
   50% {
     border-color: orange;
     box-shadow: 0 0 20px orange;
-    transform: scale(1.02);
   }
   100% {
     border-color: red;
     box-shadow: 0 0 10px red;
-    transform: scale(1);
   }
 }
 

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -1410,6 +1410,23 @@ export async function initializeIndexPage() {
         el.addEventListener("input", () => {
           saveBuildButton.disabled = false;
           saveBuildButton.style.backgroundColor = "#963325";
+
+          if (id === "buildOrderTitleInput") {
+            const titleText = document.getElementById("buildOrderTitleText");
+            const title = el.value.trim().toLowerCase();
+            const savedBuilds = getSavedBuilds();
+            const currentId = getCurrentBuildId();
+            const duplicate = savedBuilds.some(
+              (b) =>
+                b.title.toLowerCase() === title && b.encodedTitle !== currentId
+            );
+            if (duplicate) {
+              saveBuildButton.disabled = true;
+              if (titleText) titleText.classList.add("highlight");
+            } else if (titleText) {
+              titleText.classList.remove("highlight");
+            }
+          }
         });
         el.dataset.monitorAttached = "true";
       }


### PR DESCRIPTION
## Summary
- prevent saving builds with duplicate titles
- keep title highlighted while duplicate exists
- remove scale transform from highlight animation
- bump version to 0.5.7134

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684adf798f3c832a8c0beb51813f7051