### PR TITLE
Add user stats modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,8 @@
             <img src="img/SVG/clan.svg" class="menu-icon" /> Clans
           </button>
           <hr class="menu-divider" />
+          <button id="showStatsButton" class="user-menu-button">📊 My Stats</button>
+          <hr class="menu-divider" />
           <button class="menu-item" id="settingsBtn">
             <img src="img/SVG/settings.svg" class="menu-icon" /> Settings
           </button>
@@ -676,6 +678,14 @@
       </div>
     </div>
 
+    <div id="userStatsModal" class="modal">
+      <div class="modal-content small-modal">
+        <span class="close-modal" id="closeUserStatsModal">&times;</span>
+        <h3>My Stats</h3>
+        <div id="userStatsContent">Loading...</div>
+      </div>
+    </div>
+
     <!-- Modal for delete notification -->
     <div id="deleteConfirmationModal" class="modal">
       <div class="modal-content">
@@ -797,7 +807,7 @@
 
 
 
-      <p>Version 0.5.8030</p>
+      <p>Version 0.5.8031</p>
 
 
 

--- a/src/app.js
+++ b/src/app.js
@@ -214,6 +214,7 @@ export function initializeAuthUI() {
   const showClanBtn = document.getElementById("showClanModalButton");
   const mapVetoBtn = document.getElementById("mapVetoBtn");
   const settingsMenuItem = document.getElementById("settingsBtn");
+  const statsMenuItem = document.getElementById("showStatsButton");
   const switchAccountMenuItem = document.getElementById("switchAccountBtn");
   const signOutMenuItem = document.getElementById("signOutBtn");
   const deleteAccountMenuItem = document.getElementById("deleteAccountBtn");
@@ -252,6 +253,7 @@ export function initializeAuthUI() {
       if (mapVetoBtn) mapVetoBtn.style.display = "block";
       if (showClanBtn) showClanBtn.style.display = "block";
       if (settingsMenuItem) settingsMenuItem.style.display = "block";
+      if (statsMenuItem) statsMenuItem.style.display = "block";
       if (switchAccountMenuItem) switchAccountMenuItem.style.display = "block";
       if (signOutMenuItem) signOutMenuItem.style.display = "block";
       if (deleteAccountMenuItem) deleteAccountMenuItem.style.display = "block";
@@ -266,6 +268,7 @@ export function initializeAuthUI() {
       if (mapVetoBtn) mapVetoBtn.style.display = "block";
       if (showClanBtn) showClanBtn.style.display = "none";
       if (settingsMenuItem) settingsMenuItem.style.display = "none";
+      if (statsMenuItem) statsMenuItem.style.display = "none";
       if (switchAccountMenuItem) switchAccountMenuItem.style.display = "none";
       if (signOutMenuItem) signOutMenuItem.style.display = "none";
       if (deleteAccountMenuItem) deleteAccountMenuItem.style.display = "none";

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -76,6 +76,7 @@ import {
   setSavedBuilds,
   saveSavedBuildsToLocalStorage,
 } from "../buildStorage.js";
+import { showUserStats, closeUserStats } from "../stats.js";
 import { setupCatActivationOnInput } from "../helpers/companion.js";
 import {
   getCurrentBuildId,
@@ -960,6 +961,23 @@ export async function initializeIndexPage() {
 
   document.getElementById("mapVetoBtn")?.addEventListener("click", () => {
     window.location.href = "/veto.html";
+  });
+
+  document.getElementById("showStatsButton")?.addEventListener("click", () => {
+    const userMenu = document.getElementById("userMenu");
+    if (userMenu) userMenu.style.display = "none";
+    showUserStats();
+  });
+
+  document
+    .getElementById("closeUserStatsModal")
+    ?.addEventListener("click", closeUserStats);
+
+  window.addEventListener("mousedown", (event) => {
+    const modal = document.getElementById("userStatsModal");
+    if (modal && event.target === modal) {
+      closeUserStats();
+    }
   });
 
   // Close the avatar submenu after selecting any menu item

--- a/src/js/modules/stats.js
+++ b/src/js/modules/stats.js
@@ -1,0 +1,83 @@
+import { collection, query, where, getDocs } from "https://www.gstatic.com/firebasejs/11.2.0/firebase-firestore.js";
+import { auth, db } from "../../app.js";
+import { showToast } from "./toastHandler.js";
+
+export async function fetchUserStats() {
+  const user = auth.currentUser;
+  if (!user) return null;
+
+  try {
+    // Personal builds
+    const buildsSnap = await getDocs(collection(db, `users/${user.uid}/builds`));
+    const totalBuilds = buildsSnap.size;
+    let totalImported = 0;
+    buildsSnap.forEach((d) => {
+      if (d.data().imported) totalImported++;
+    });
+
+    // Published builds
+    const pubQuery = query(
+      collection(db, "publishedBuilds"),
+      where("publisherId", "==", user.uid)
+    );
+    const pubSnap = await getDocs(pubQuery);
+
+    let totalPublished = 0;
+    let totalViews = 0;
+    let totalUpvotes = 0;
+    let mostPopularTitle = null;
+    let bestScore = -1;
+    pubSnap.forEach((doc) => {
+      totalPublished++;
+      const data = doc.data();
+      const views = data.views || 0;
+      const upvotes = data.upvotes || 0;
+      totalViews += views;
+      totalUpvotes += upvotes;
+      const score = views + upvotes;
+      if (score > bestScore) {
+        bestScore = score;
+        mostPopularTitle = data.title || "Untitled Build";
+      }
+    });
+
+    return {
+      totalBuilds,
+      totalPublished,
+      totalImported,
+      totalViews,
+      totalUpvotes,
+      mostPopularTitle,
+    };
+  } catch (err) {
+    console.error("Failed to fetch user stats", err);
+    showToast("Error loading stats", "error");
+    return null;
+  }
+}
+
+export async function showUserStats() {
+  const modal = document.getElementById("userStatsModal");
+  const contentEl = document.getElementById("userStatsContent");
+  if (!modal || !contentEl) return;
+
+  modal.style.display = "block";
+  contentEl.textContent = "Loading...";
+
+  const stats = await fetchUserStats();
+  if (!stats) return;
+
+  contentEl.innerHTML = `
+    <p>Total Builds Created: ${stats.totalBuilds}</p>
+    <p>Total Published Builds: ${stats.totalPublished}</p>
+    <p>Total Imported Builds: ${stats.totalImported}</p>
+    <p>Total Views on Published Builds: ${stats.totalViews}</p>
+    <p>Total Upvotes on Published Builds: ${stats.totalUpvotes}</p>
+    <p>Most Popular Build: ${stats.mostPopularTitle || "N/A"}</p>
+  `;
+}
+
+export function closeUserStats() {
+  const modal = document.getElementById("userStatsModal");
+  if (modal) modal.style.display = "none";
+}


### PR DESCRIPTION
## Summary
- create stats.js module to gather user build statistics
- register new My Stats button in user menu
- show or hide new button based on auth state
- open/close stats modal with build stats
- bump version number to 0.5.8031

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859d54b666c832aa5b53d14c440db34