### PR TITLE
Fix overlay spinner placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,9 @@
             </div>
           </div>
           <textarea id="buildOrderInput" placeholder="Spawning Pool"></textarea>
+          <div id="optionsLoadingWrapper">
+            <div class="spinner"></div>
+          </div>
         </div>
       </div>
     </div>
@@ -788,9 +791,6 @@
       </div>
     </div>
 
-    <div id="optionsLoadingWrapper">
-      <div class="spinner"></div>
-    </div>
 
 
 
@@ -825,7 +825,7 @@
 
 
 
-      <p>Version 0.5.8064</p>
+      <p>Version 0.5.8065</p>
 
 
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4897,6 +4897,12 @@ optgroup[label="Terran"] {
 #optionsLoadingWrapper {
   display: none;
   justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }
 #cookieBanner {
   display: none;


### PR DESCRIPTION
## Summary
- overlay replay loader spinner over buildOrderInput
- bump version to 0.5.8065

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d29c76308832ab69f8e9d9d3bd9ea