### PR TITLE
Modify template menu to new buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,18 +201,11 @@
       <div id="buildOrderInputField" class="hideable-section">
         <div class="template-wrapper">
           <div class="dropdown">
-            <svg id="templateMenuButton" class="template-icon-button" data-tooltip="Template & Replay" width="60"
-              height="26" viewBox="0 0 60 26" xmlns="http://www.w3.org/2000/svg">
-              <polygon points="0,0 33,0 60,26 0,26"></polygon>
-              <path d="M0,0 L33,0" />
-              <path d="M33,0 L60,26" />
-              <path d="M60,26 L0,26" />
-              <path d="M0,26 L0,0" />
-              <text x="10" y="20">+</text>
-            </svg>
+            <div class="template-buttons">
+              <button id="templateMenuButton" class="template-btn" data-tooltip="Template">Template</button>
+              <button id="replayButton" class="template-btn" data-tooltip="Replay">Replay</button>
+            </div>
             <div id="templateDropdown" class="dropdown-content">
-              <button id="parseReplayButton" class="btn">Upload From Replay</button>
-              <hr class="dropdown-divider" />
               <button id="openTemplatesButton">Open Templates</button>
               <button id="saveTemplateButton">Save Template</button>
             </div>
@@ -818,7 +811,7 @@
 
 
 
-      <p>Version 0.5.8067</p>
+      <p>Version 0.5.8068</p>
 
 
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -705,6 +705,29 @@ button:hover {
   width: 100%;
 }
 
+.template-buttons {
+  position: absolute;
+  top: -28px;
+  left: 0;
+  display: flex;
+}
+
+.template-buttons .template-btn {
+  background-color: #383838;
+  color: #fff;
+  border: 1px solid #444;
+  border-bottom: none;
+  padding: 4px 8px;
+  cursor: pointer;
+  margin: 0;
+  height: 26px;
+  line-height: 18px;
+}
+
+.template-buttons .template-btn + .template-btn {
+  border-left: none;
+}
+
 .template-icon-button {
   position: absolute;
   top: -22px;

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -498,6 +498,11 @@ export async function initializeIndexPage() {
     if (input) input.click();
   });
 
+  safeAdd("replayButton", "click", () => {
+    const input = document.getElementById("replayFileInput");
+    if (input) input.click();
+  });
+
   async function populateReplayOptions(file) {
     const loader = document.getElementById("optionsLoadingWrapper");
     if (loader) loader.style.display = "flex";


### PR DESCRIPTION
## Summary
- split template menu into Template and Replay buttons
- style new buttons
- bump version number to 0.5.8068

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d45b5ab74832a8aa5c52d930a98fe