### PR TITLE
keywords-move template buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,22 @@
       <div class="toggle-header">
         <div id="editModeBanner"></div>
 
+        <div class="toggle-header-left">
+          <div class="dropdown">
+            <div class="template-buttons">
+              <button id="templateMenuButton" class="template-btn" data-tooltip="Template">
+                <img src="img/SVG/template.svg" alt="Template" class="svg-icon" />
+              </button>
+              <button id="replayButton" class="template-btn" data-tooltip="Replay">
+                <img src="img/SVG/upload.svg" alt="Upload" class="svg-icon" />
+              </button>
+            </div>
+            <div id="templateDropdown" class="dropdown-content">
+              <button id="openTemplatesButton">Open Templates</button>
+              <button id="saveTemplateButton">Save Template</button>
+            </div>
+          </div>
+        </div>
         <div id="box">
 
 
@@ -195,20 +211,6 @@
             <img src="img/SVG/community.svg" alt="Community Icon" class="svg-icon"> <span class="btn-text">Community
               Builds</span>
           </button>
-          <div class="dropdown">
-            <div class="template-buttons">
-              <button id="templateMenuButton" class="template-btn" data-tooltip="Template">
-                <img src="img/SVG/template.svg" alt="Template" class="svg-icon" />
-              </button>
-              <button id="replayButton" class="template-btn" data-tooltip="Replay">
-                <img src="img/SVG/upload.svg" alt="Upload" class="svg-icon" />
-              </button>
-            </div>
-            <div id="templateDropdown" class="dropdown-content">
-              <button id="openTemplatesButton">Open Templates</button>
-              <button id="saveTemplateButton">Save Template</button>
-            </div>
-          </div>
           <button id="buildOrderHelpBtn" class="help-circle animated-help" data-tooltip="Help">?</button>
         </div>
       </div>
@@ -815,7 +817,7 @@
 
 
 
-      <p>Version 0.5.8071</p>
+      <p>Version 0.5.8072</p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -195,11 +195,6 @@
             <img src="img/SVG/community.svg" alt="Community Icon" class="svg-icon"> <span class="btn-text">Community
               Builds</span>
           </button>
-          <button id="buildOrderHelpBtn" class="help-circle animated-help" data-tooltip="Help">?</button>
-        </div>
-      </div>
-      <div id="buildOrderInputField" class="hideable-section">
-        <div class="template-wrapper">
           <div class="dropdown">
             <div class="template-buttons">
               <button id="templateMenuButton" class="template-btn" data-tooltip="Template">
@@ -214,6 +209,11 @@
               <button id="saveTemplateButton">Save Template</button>
             </div>
           </div>
+          <button id="buildOrderHelpBtn" class="help-circle animated-help" data-tooltip="Help">?</button>
+        </div>
+      </div>
+      <div id="buildOrderInputField" class="hideable-section">
+        <div class="template-wrapper">
           <textarea id="buildOrderInput" placeholder="Spawning Pool"></textarea>
           <div id="optionsLoadingWrapper">
             <div class="spinner"></div>
@@ -815,7 +815,7 @@
 
 
 
-      <p>Version 0.5.8070</p>
+      <p>Version 0.5.8071</p>
 
 
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -602,6 +602,11 @@ button:hover {
   gap: 8px;
 }
 
+.toggle-header-left {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
 .toggle-header-right {
   display: flex;
   gap: 8px;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -706,9 +706,6 @@ button:hover {
 }
 
 .template-buttons {
-  position: absolute;
-  top: -28px;
-  left: 0;
   display: flex;
 }
 


### PR DESCRIPTION
## Summary
- move Template and Replay buttons into the toggle-header
- clean up styles for template buttons
- bump version to 0.5.8071

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d52260b14832a8718d6fea528172d