### PR TITLE
Add game selector and dynamic data loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,12 @@
   <div id="top-logo-container">
     <img src="img/toplogo.webp" alt="Z-Build Order Logo" class="top-logo" />
   </div>
+  <div id="game-select-container">
+    <select id="gameSelect">
+      <option value="sc2">StarCraft 2</option>
+      <option value="aoe2">Age of Empires 2</option>
+    </select>
+  </div>
   <div id="toast-container"></div>
 
   <!-- Auth Container -->
@@ -816,7 +822,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8072</p>
+      <p>Version 0.5.8073</p>
 
 
 
@@ -922,6 +928,16 @@
         <p id="supportersList">No supporters yet.</p>
       </div>
     </div>
+    <script>
+      const gameSelectEl = document.getElementById('gameSelect');
+      if (gameSelectEl) {
+        gameSelectEl.value = localStorage.getItem('selectedGame') || 'sc2';
+        gameSelectEl.addEventListener('change', () => {
+          localStorage.setItem('selectedGame', gameSelectEl.value);
+          location.reload();
+        });
+      }
+    </script>
     <script type="module" src="./src/initMain.js"></script>
 
 

--- a/src/initMain.js
+++ b/src/initMain.js
@@ -1,8 +1,12 @@
 import './app.js';
 import { initializeAuthUI } from './app.js';
 import { initializeIndexPage } from './js/modules/init/indexPageInit.js';
+import { setSelectedGame } from './js/modules/gameSettings.js';
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (!localStorage.getItem('selectedGame')) {
+    setSelectedGame('sc2');
+  }
   initializeAuthUI();
   initializeIndexPage();
 });

--- a/src/js/data/gameData.js
+++ b/src/js/data/gameData.js
@@ -1,0 +1,11 @@
+import { getSelectedGame } from '../modules/gameSettings.js';
+
+const selectedGame = getSelectedGame();
+let data;
+if (selectedGame === 'aoe2') {
+  data = await import('./games/aoe2/index.js');
+} else {
+  data = await import('./games/sc2/index.js');
+}
+
+export const { units, structures, upgrades, unitImages, structureImages, upgradeImages } = data;

--- a/src/js/data/games/aoe2/images.js
+++ b/src/js/data/games/aoe2/images.js
@@ -1,0 +1,3 @@
+export const unitImages = {};
+export const structureImages = {};
+export const upgradeImages = {};

--- a/src/js/data/games/aoe2/index.js
+++ b/src/js/data/games/aoe2/index.js
@@ -1,0 +1,4 @@
+export { units } from './units.js';
+export { structures } from './structures.js';
+export { upgrades } from './upgrades.js';
+export { unitImages, structureImages, upgradeImages } from './images.js';

--- a/src/js/data/games/aoe2/structures.js
+++ b/src/js/data/games/aoe2/structures.js
@@ -1,0 +1,1 @@
+export const structures = ['town center', 'house', 'barracks'];

--- a/src/js/data/games/aoe2/units.js
+++ b/src/js/data/games/aoe2/units.js
@@ -1,0 +1,3 @@
+export const units = {
+  generic: ['villager', 'militia', 'archer']
+};

--- a/src/js/data/games/aoe2/upgrades.js
+++ b/src/js/data/games/aoe2/upgrades.js
@@ -1,0 +1,1 @@
+export const upgrades = ['loom', 'fletching'];

--- a/src/js/data/games/sc2/index.js
+++ b/src/js/data/games/sc2/index.js
@@ -1,0 +1,4 @@
+export { units } from '../../units.js';
+export { structures } from '../../structures.js';
+export { upgrades } from '../../upgrades.js';
+export { unitImages, structureImages, upgradeImages } from '../../images.js';

--- a/src/js/modules/autoCorrect.js
+++ b/src/js/modules/autoCorrect.js
@@ -1,7 +1,11 @@
-import { units } from "../data/units.js";
-import { structures } from "../data/structures.js";
-import { upgrades } from "../data/upgrades.js";
-import { upgradeImages, unitImages, structureImages } from "../data/images.js";
+import {
+  units,
+  structures,
+  upgrades,
+  unitImages,
+  structureImages,
+  upgradeImages,
+} from "../data/gameData.js";
 import { analyzeBuildOrder } from "./uiHandlers.js";
 import { isBracketInputEnabled } from "./settings.js";
 import DOMPurify from "dompurify";

--- a/src/js/modules/gameSettings.js
+++ b/src/js/modules/gameSettings.js
@@ -1,0 +1,7 @@
+export function getSelectedGame() {
+  return localStorage.getItem('selectedGame') || 'sc2';
+}
+
+export function setSelectedGame(game) {
+  localStorage.setItem('selectedGame', game);
+}

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -894,7 +894,7 @@ export async function initializeIndexPage() {
   // --- Other Initializations
   initializeSectionToggles();
   initializeTextareaClickHandler();
-  initializeAutoCorrect();
+  await initializeAutoCorrect();
   updateSupplyColumnVisibility();
   updateBuildInputVisibility();
   updateBuildInputPlaceholder();

--- a/src/js/modules/textFormatters.js
+++ b/src/js/modules/textFormatters.js
@@ -1,8 +1,12 @@
 // Import required data and utilities
-import { units } from "../data/units.js";
-import { structures } from "../data/structures.js";
-import { upgrades } from "../data/upgrades.js";
-import { unitImages, structureImages, upgradeImages } from "../data/images.js";
+import {
+  units,
+  structures,
+  upgrades,
+  unitImages,
+  structureImages,
+  upgradeImages,
+} from "../data/gameData.js";
 import { abbreviationMap } from "../data/abbreviationMap.js";
 import DOMPurify from "dompurify";
 


### PR DESCRIPTION
## Summary
- allow game selection from new dropdown in index page
- remember chosen game with `localStorage`
- load data modules dynamically based on selection
- initialize with default game if none saved
- bump version to 0.5.8073

## Testing
- `node -c src/js/data/gameData.js`
- `node -c src/js/modules/autoCorrect.js`
- `node -c src/js/modules/textFormatters.js`

------
https://chatgpt.com/codex/tasks/task_e_6861d2b21754832a969e3a5af3083c3b