### PR TITLE
Add dynamic game data loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,7 +816,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8072</p>
+      <p>Version 0.5.8073</p>
 
 
 

--- a/src/js/data/getGameData.js
+++ b/src/js/data/getGameData.js
@@ -1,0 +1,37 @@
+import { getCurrentGame } from '../modules/states/gameState.js';
+
+let cachedGame = null;
+let cachedData = null;
+
+export async function loadGameData() {
+  const game = getCurrentGame();
+  if (cachedGame === game && cachedData) return cachedData;
+
+  let unitsModule, structuresModule, upgradesModule, imagesModule, abbrModule;
+
+  if (game === 'stormgate') {
+    unitsModule = await import('./stormgate/units.js');
+    structuresModule = await import('./stormgate/structures.js');
+    upgradesModule = await import('./stormgate/upgrades.js');
+    imagesModule = await import('./stormgate/images.js');
+    abbrModule = await import('./stormgate/abbreviations.js');
+  } else {
+    unitsModule = await import('./units.js');
+    structuresModule = await import('./structures.js');
+    upgradesModule = await import('./upgrades.js');
+    imagesModule = await import('./images.js');
+    abbrModule = await import('./abbreviationMap.js');
+  }
+
+  cachedData = {
+    units: unitsModule.units,
+    structures: structuresModule.structures,
+    upgrades: upgradesModule.upgrades,
+    unitImages: imagesModule.unitImages,
+    structureImages: imagesModule.structureImages,
+    upgradeImages: imagesModule.upgradeImages,
+    abbreviationMap: abbrModule.abbreviationMap,
+  };
+  cachedGame = game;
+  return cachedData;
+}

--- a/src/js/data/stormgate/abbreviations.js
+++ b/src/js/data/stormgate/abbreviations.js
@@ -1,0 +1,14 @@
+export const abbreviationMap = {
+  Structures: {
+    op: "outpost",
+    barr: "barracks",
+  },
+  Units: {
+    sc: "scout",
+    fi: "fiend",
+  },
+  Upgrades: {
+    wep: "weapon upgrade",
+    arm: "armor upgrade",
+  },
+};

--- a/src/js/data/stormgate/images.js
+++ b/src/js/data/stormgate/images.js
@@ -1,0 +1,3 @@
+export const unitImages = {};
+export const structureImages = {};
+export const upgradeImages = {};

--- a/src/js/data/stormgate/structures.js
+++ b/src/js/data/stormgate/structures.js
@@ -1,0 +1,5 @@
+export const structures = [
+  "outpost",
+  "barracks",
+  "forge",
+];

--- a/src/js/data/stormgate/units.js
+++ b/src/js/data/stormgate/units.js
@@ -1,0 +1,4 @@
+export const units = {
+  vanguard: ["scout", "lancer", "tank"],
+  infernal: ["imp", "fiend", "brute"],
+};

--- a/src/js/data/stormgate/upgrades.js
+++ b/src/js/data/stormgate/upgrades.js
@@ -1,0 +1,4 @@
+export const upgrades = [
+  "weapon upgrade",
+  "armor upgrade",
+];

--- a/src/js/modules/autoCorrect.js
+++ b/src/js/modules/autoCorrect.js
@@ -1,7 +1,11 @@
-import { units } from "../data/units.js";
-import { structures } from "../data/structures.js";
-import { upgrades } from "../data/upgrades.js";
-import { upgradeImages, unitImages, structureImages } from "../data/images.js";
+import { loadGameData } from "../data/getGameData.js";
+
+let units,
+  structures,
+  upgrades,
+  unitImages,
+  structureImages,
+  upgradeImages;
 import { analyzeBuildOrder } from "./uiHandlers.js";
 import { isBracketInputEnabled } from "./settings.js";
 import DOMPurify from "dompurify";
@@ -62,7 +66,15 @@ function positionPopupAtCaret(inputField, popup) {
 }
 
 // Function to initialize the autocomplete feature
-export function initializeAutoCorrect() {
+export async function initializeAutoCorrect() {
+  ({
+    units,
+    structures,
+    upgrades,
+    unitImages,
+    structureImages,
+    upgradeImages,
+  } = await loadGameData());
   const inputField = document.getElementById("buildOrderInput");
   const popup = document.getElementById("autocomplete-popup");
 

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -18,6 +18,7 @@ import {
   syncToPublishedBuild,
 } from "../buildManagement.js";
 import { initializeAutoCorrect } from "../autoCorrect.js";
+import { loadGameData } from "../../data/getGameData.js";
 import { populateBuildDetails, analyzeBuildOrder } from "../uiHandlers.js";
 import { showToast } from "../toastHandler.js";
 import { updateYouTubeEmbed } from "../youtube.js";
@@ -159,6 +160,8 @@ let currentBuildFilter = "all";
  ----------------- */
 export async function initializeIndexPage() {
   console.log("🛠 Initializing Index Page");
+
+  await loadGameData();
 
   const restoreCommunity = localStorage.getItem("restoreCommunityModal");
   const filterType = localStorage.getItem("communityFilterType");
@@ -894,7 +897,7 @@ export async function initializeIndexPage() {
   // --- Other Initializations
   initializeSectionToggles();
   initializeTextareaClickHandler();
-  initializeAutoCorrect();
+  await initializeAutoCorrect();
   updateSupplyColumnVisibility();
   updateBuildInputVisibility();
   updateBuildInputPlaceholder();

--- a/src/js/modules/states/gameState.js
+++ b/src/js/modules/states/gameState.js
@@ -1,0 +1,13 @@
+const GAME_KEY = 'selectedGame';
+
+export function getCurrentGame() {
+  return localStorage.getItem(GAME_KEY) || 'sc2';
+}
+
+export function setCurrentGame(game) {
+  if (game) {
+    localStorage.setItem(GAME_KEY, game);
+  } else {
+    localStorage.removeItem(GAME_KEY);
+  }
+}

--- a/src/js/modules/textFormatters.js
+++ b/src/js/modules/textFormatters.js
@@ -1,10 +1,16 @@
 // Import required data and utilities
-import { units } from "../data/units.js";
-import { structures } from "../data/structures.js";
-import { upgrades } from "../data/upgrades.js";
-import { unitImages, structureImages, upgradeImages } from "../data/images.js";
-import { abbreviationMap } from "../data/abbreviationMap.js";
+import { loadGameData } from "../data/getGameData.js";
 import DOMPurify from "dompurify";
+
+const {
+  units,
+  structures,
+  upgrades,
+  unitImages,
+  structureImages,
+  upgradeImages,
+  abbreviationMap,
+} = await loadGameData();
 
 // Utility: Capitalize the first letter of a string
 export function capitalizeFirstLetter(text) {

--- a/src/js/modules/uiHandlers.js
+++ b/src/js/modules/uiHandlers.js
@@ -7,7 +7,7 @@ import {
   formatActionText,
   formatWorkersOrTimestampText,
 } from "./textFormatters.js";
-import { abbreviationMap } from "../data/abbreviationMap.js";
+import { loadGameData } from "../data/getGameData.js";
 import { setCurrentBuildId } from "./states/buildState.js";
 import { parseBuildOrder } from "./utils.js";
 import { isBracketInputEnabled } from "./settings.js";
@@ -415,7 +415,8 @@ function generateAbbrSection(title, abbrObj) {
   `;
 }
 
-export function showBuildOrderHelpModal() {
+export async function showBuildOrderHelpModal() {
+  const { abbreviationMap } = await loadGameData();
   const modal = document.getElementById("buildOrderHelpModal");
   const contentDiv = document.getElementById("buildOrderHelpContent");
 

--- a/src/js/modules/viewBuild.js
+++ b/src/js/modules/viewBuild.js
@@ -12,6 +12,7 @@ import {
   where,
 } from "https://www.gstatic.com/firebasejs/11.2.0/firebase-firestore.js";
 import { formatActionText } from "../modules/textFormatters.js"; // ✅ Format build steps
+import { loadGameData } from "../data/getGameData.js";
 import {
   MapAnnotations,
   renderMapCards,
@@ -97,6 +98,7 @@ async function incrementBuildViews(buildId) {
 }
 
 async function loadBuild() {
+  await loadGameData();
   const pathParts = window.location.pathname.split("/");
   const buildId = pathParts[2]; // because URL is /build/abc123
 


### PR DESCRIPTION
## Summary
- introduce game data loader and state to switch between SC2 and Stormgate
- add placeholder Stormgate data files
- load game data in index and build views
- update autocomplete and formatters to use dynamic data
- tweak help modal to load abbreviations on demand
- bump version number

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861d304f8dc832aa26a5f3b3757c6bd