### PR TITLE
focus fullscreen modal - add focus mode for build viewing

### DIFF
--- a/index.html
+++ b/index.html
@@ -820,7 +820,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8078</p>
+      <p>Version 0.5.8079</p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -820,7 +820,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8080</p>
+      <p>Version 0.5.8081</p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -820,7 +820,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8074</p>
+      <p>Version 0.5.8075</p>
 
 
 
@@ -928,7 +928,7 @@
     </div>
 
     <!-- Focus Modal for build output -->
-    <div id="focusModal" class="modal fullscreen-modal">
+    <div id="focusModal" class="modal">
       <div class="modal-content">
         <span class="close-modal" id="closeFocusModal">&times;</span>
         <div class="font-controls">

--- a/index.html
+++ b/index.html
@@ -275,7 +275,11 @@
       <table id="buildOrderTable">
         <tr>
           <th id="supplyHeader"><span class="full-text">Supply/Time</span><span class="short-text">S/T</span></th>
-          <th>Action</th>
+          <th class="action-header">Action
+            <button id="openFocusModal" class="focus-btn" title="Focus Mode">
+              <img src="img/SVG/expand-top-right-svgrepo-com.svg" alt="Focus">
+            </button>
+          </th>
         </tr>
       </table>
     </div>
@@ -816,7 +820,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8073</p>
+      <p>Version 0.5.8074</p>
 
 
 
@@ -920,6 +924,18 @@
         <span class="close-modal" id="closeSupportersModal">×</span>
         <h3>Patreon Supporters</h3>
         <p id="supportersList">No supporters yet.</p>
+      </div>
+    </div>
+
+    <!-- Focus Modal for build output -->
+    <div id="focusModal" class="modal fullscreen-modal">
+      <div class="modal-content">
+        <span class="close-modal" id="closeFocusModal">&times;</span>
+        <div class="font-controls">
+          <button id="increaseFontBtn">A+</button>
+          <button id="decreaseFontBtn">A-</button>
+        </div>
+        <div id="focusContent" class="focus-content"></div>
       </div>
     </div>
     <script type="module" src="./src/initMain.js"></script>

--- a/index.html
+++ b/index.html
@@ -820,7 +820,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8076</p>
+      <p>Version 0.5.8077</p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -820,7 +820,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8075</p>
+      <p>Version 0.5.8076</p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -816,7 +816,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8072</p>
+      <p>Version 0.5.8073</p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -820,7 +820,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8079</p>
+      <p>Version 0.5.8080</p>
 
 
 
@@ -839,6 +839,9 @@
       <button id="cookieAccept" class="cookie-btn">Accept</button>
       <button id="cookieDecline" class="cookie-btn">Decline</button>
     </div>
+
+    <!-- End Footer -->
+  </div>
 
     <!-- Privacy Policy Modal -->
     <div id="privacyModal" class="modal">

--- a/index.html
+++ b/index.html
@@ -820,7 +820,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8077</p>
+      <p>Version 0.5.8078</p>
 
 
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -809,9 +809,9 @@ textarea::-webkit-scrollbar-thumb:hover {
 .structure-image {
   width: 30px; /* Adjust as necessary */
   height: 30px;
-  margin-left: 5px;
+  display: block;
+  margin: 0 auto 4px;
   border-radius: 7px; /* Rounded corners */
-  vertical-align: middle; /* Align the image properly with the text */
   object-fit: cover;
 }
 
@@ -4966,10 +4966,13 @@ optgroup[label="Terran"] {
 }
 
 .font-controls {
+  position: absolute;
+  top: 10px;
+  left: 10px;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 8px;
-  margin: 20px 0 10px 0;
+  margin: 0;
 }
 
 .font-controls button {
@@ -5002,6 +5005,7 @@ optgroup[label="Terran"] {
   right: 4px;
   top: 50%;
   transform: translateY(-50%);
+  margin: 0;
 }
 
 .focus-btn:hover {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4957,6 +4957,11 @@ optgroup[label="Terran"] {
   position: relative;
   display: flex;
   flex-direction: column;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  justify-content: center;
+  align-items: center;
 }
 
 .font-controls {
@@ -4977,7 +4982,11 @@ optgroup[label="Terran"] {
 
 #focusContent {
   overflow-y: auto;
-  flex: 1;
+  flex: none;
+  max-height: 80%;
+  display: flex;
+  justify-content: center;
+  width: 100%;
 }
 
 .focus-btn {
@@ -4987,6 +4996,10 @@ optgroup[label="Terran"] {
   position: absolute;
   right: 4px;
   top: 50%;
+  transform: translateY(-50%);
+}
+
+.focus-btn:hover {
   transform: translateY(-50%);
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -810,6 +810,7 @@ textarea::-webkit-scrollbar-thumb:hover {
   width: 30px; /* Adjust as necessary */
   height: 30px;
   margin-left: 5px;
+  display: inline-flex;
   border-radius: 7px; /* Rounded corners */
   vertical-align: middle; /* Align the image properly with the text */
   object-fit: cover;
@@ -4994,7 +4995,9 @@ optgroup[label="Terran"] {
 }
 
 #focusModal #buildOrderTable {
-  margin: 0 20px;
+  margin: 0 auto;
+  padding: 0 20px;
+  max-width: 1200px;
 }
 
 .focus-btn {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4959,6 +4959,7 @@ optgroup[label="Terran"] {
   flex-direction: column;
   width: 100%;
   height: 100%;
+  max-width: 100%;
   margin: 0;
   justify-content: center;
   align-items: center;
@@ -4989,6 +4990,10 @@ optgroup[label="Terran"] {
   width: 100%;
 }
 
+#focusModal #buildOrderTable {
+  margin: 0 20px;
+}
+
 .focus-btn {
   background: none;
   border: none;
@@ -5004,8 +5009,8 @@ optgroup[label="Terran"] {
 }
 
 .focus-btn img {
-  width: 24px;
-  height: 24px;
+  width: 16px;
+  height: 16px;
   filter: invert(1);
 }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -835,6 +835,10 @@ textarea::-webkit-scrollbar-thumb:hover {
   background-color: rgba(0, 0, 0, 0.4); /* Black with opacity */
 }
 
+body.modal-open {
+  overflow: hidden;
+}
+
 /* Modal content */
 .modal-content {
   background-color: rgba(
@@ -4998,6 +5002,16 @@ optgroup[label="Terran"] {
   margin: 0 auto;
   padding: 0 20px;
   max-width: 1200px;
+}
+
+/* Scale images with font size inside focus modal */
+#focusContent .term-image,
+#focusContent .unit-image,
+#focusContent .structure-image,
+#focusContent .ability-image,
+#focusContent .upgrade-image {
+  width: 1.875em;
+  height: 1.875em;
 }
 
 .focus-btn {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4951,3 +4951,47 @@ optgroup[label="Terran"] {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* Focus Modal Styles */
+.fullscreen-modal .modal-content {
+  margin: 0;
+  max-width: none;
+  width: 100%;
+  height: 100%;
+  background: #1e1e1e;
+  display: flex;
+  flex-direction: column;
+}
+
+.font-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.font-controls button {
+  background: #333;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+#focusContent {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.focus-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.focus-btn img {
+  width: 24px;
+  height: 24px;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4953,12 +4953,8 @@ optgroup[label="Terran"] {
 }
 
 /* Focus Modal Styles */
-.fullscreen-modal .modal-content {
-  margin: 0;
-  max-width: none;
-  width: 100%;
-  height: 100%;
-  background: #1e1e1e;
+#focusModal .modal-content {
+  position: relative;
   display: flex;
   flex-direction: column;
 }
@@ -4967,7 +4963,7 @@ optgroup[label="Terran"] {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-bottom: 10px;
+  margin: 20px 0 10px 0;
 }
 
 .font-controls button {
@@ -4988,10 +4984,18 @@ optgroup[label="Terran"] {
   background: none;
   border: none;
   cursor: pointer;
-  margin-left: 10px;
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .focus-btn img {
   width: 24px;
   height: 24px;
+  filter: invert(1);
+}
+
+.action-header {
+  position: relative;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -809,9 +809,9 @@ textarea::-webkit-scrollbar-thumb:hover {
 .structure-image {
   width: 30px; /* Adjust as necessary */
   height: 30px;
-  display: block;
-  margin: 0 auto 4px;
+  margin-left: 5px;
   border-radius: 7px; /* Rounded corners */
+  vertical-align: middle; /* Align the image properly with the text */
   object-fit: cover;
 }
 

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -372,12 +372,8 @@ input[type="text"]:disabled {
 }
 
 /* Focus Modal Styles */
-.fullscreen-modal .modal-content {
-  margin: 0;
-  max-width: none;
-  width: 100%;
-  height: 100%;
-  background: #1e1e1e;
+#focusModal .modal-content {
+  position: relative;
   display: flex;
   flex-direction: column;
 }
@@ -386,7 +382,7 @@ input[type="text"]:disabled {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-bottom: 10px;
+  margin: 20px 0 10px 0;
 }
 
 .font-controls button {
@@ -407,11 +403,19 @@ input[type="text"]:disabled {
   background: none;
   border: none;
   cursor: pointer;
-  margin-left: 10px;
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .focus-btn img {
   width: 24px;
   height: 24px;
+  filter: invert(1);
+}
+
+.action-header {
+  position: relative;
 }
 

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -385,10 +385,13 @@ input[type="text"]:disabled {
 }
 
 .font-controls {
+  position: absolute;
+  top: 10px;
+  left: 10px;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 8px;
-  margin: 20px 0 10px 0;
+  margin: 0;
 }
 
 .font-controls button {
@@ -421,6 +424,7 @@ input[type="text"]:disabled {
   right: 4px;
   top: 50%;
   transform: translateY(-50%);
+  margin: 0;
 }
 
 .focus-btn:hover {

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -413,7 +413,9 @@ input[type="text"]:disabled {
 }
 
 #focusModal #buildOrderTable {
-  margin: 0 20px;
+  margin: 0 auto;
+  padding: 0 20px;
+  max-width: 1200px;
 }
 
 .focus-btn {

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -376,6 +376,11 @@ input[type="text"]:disabled {
   position: relative;
   display: flex;
   flex-direction: column;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  justify-content: center;
+  align-items: center;
 }
 
 .font-controls {
@@ -396,7 +401,11 @@ input[type="text"]:disabled {
 
 #focusContent {
   overflow-y: auto;
-  flex: 1;
+  flex: none;
+  max-height: 80%;
+  display: flex;
+  justify-content: center;
+  width: 100%;
 }
 
 .focus-btn {
@@ -406,6 +415,10 @@ input[type="text"]:disabled {
   position: absolute;
   right: 4px;
   top: 50%;
+  transform: translateY(-50%);
+}
+
+.focus-btn:hover {
   transform: translateY(-50%);
 }
 

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -378,6 +378,7 @@ input[type="text"]:disabled {
   flex-direction: column;
   width: 100%;
   height: 100%;
+  max-width: 100%;
   margin: 0;
   justify-content: center;
   align-items: center;
@@ -408,6 +409,10 @@ input[type="text"]:disabled {
   width: 100%;
 }
 
+#focusModal #buildOrderTable {
+  margin: 0 20px;
+}
+
 .focus-btn {
   background: none;
   border: none;
@@ -423,8 +428,8 @@ input[type="text"]:disabled {
 }
 
 .focus-btn img {
-  width: 24px;
-  height: 24px;
+  width: 16px;
+  height: 16px;
   filter: invert(1);
 }
 

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -418,6 +418,16 @@ input[type="text"]:disabled {
   max-width: 1200px;
 }
 
+/* Scale images with font size inside focus modal */
+#focusContent .term-image,
+#focusContent .unit-image,
+#focusContent .structure-image,
+#focusContent .ability-image,
+#focusContent .upgrade-image {
+  width: 1.875em;
+  height: 1.875em;
+}
+
 .focus-btn {
   background: none;
   border: none;
@@ -441,5 +451,9 @@ input[type="text"]:disabled {
 
 .action-header {
   position: relative;
+}
+
+body.modal-open {
+  overflow: hidden;
 }
 

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -371,3 +371,47 @@ input[type="text"]:disabled {
   pointer-events: none;
 }
 
+/* Focus Modal Styles */
+.fullscreen-modal .modal-content {
+  margin: 0;
+  max-width: none;
+  width: 100%;
+  height: 100%;
+  background: #1e1e1e;
+  display: flex;
+  flex-direction: column;
+}
+
+.font-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.font-controls button {
+  background: #333;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+#focusContent {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.focus-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.focus-btn img {
+  width: 24px;
+  height: 24px;
+}
+

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -254,6 +254,8 @@ export async function initializeIndexPage() {
     const table = document.getElementById("buildOrderTable");
     if (table) {
       focusContent.innerHTML = table.outerHTML;
+      const btn = focusContent.querySelector("#openFocusModal");
+      if (btn) btn.remove();
       focusContent.style.fontSize = `${focusFontSize}rem`;
     }
     focusModal.style.display = "block";

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -258,11 +258,13 @@ export async function initializeIndexPage() {
       if (btn) btn.remove();
       focusContent.style.fontSize = `${focusFontSize}rem`;
     }
+    document.body.classList.add("modal-open");
     focusModal.style.display = "block";
   };
 
   const closeFocusModal = () => {
     if (focusModal) focusModal.style.display = "none";
+    document.body.classList.remove("modal-open");
   };
 
   const increaseFont = () => {

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -241,6 +241,50 @@ export async function initializeIndexPage() {
   const saveBuildButton = document.getElementById("saveBuildButton");
   const newBuildButton = document.getElementById("newBuildButton");
 
+  const focusBtn = document.getElementById("openFocusModal");
+  const focusModal = document.getElementById("focusModal");
+  const closeFocusBtn = document.getElementById("closeFocusModal");
+  const increaseFontBtn = document.getElementById("increaseFontBtn");
+  const decreaseFontBtn = document.getElementById("decreaseFontBtn");
+  const focusContent = document.getElementById("focusContent");
+  let focusFontSize = 1;
+
+  const openFocusModal = () => {
+    if (!focusModal || !focusContent) return;
+    const table = document.getElementById("buildOrderTable");
+    if (table) {
+      focusContent.innerHTML = table.outerHTML;
+      focusContent.style.fontSize = `${focusFontSize}rem`;
+    }
+    focusModal.style.display = "block";
+  };
+
+  const closeFocusModal = () => {
+    if (focusModal) focusModal.style.display = "none";
+  };
+
+  const increaseFont = () => {
+    focusFontSize = Math.min(3, focusFontSize + 0.1);
+    if (focusContent) focusContent.style.fontSize = `${focusFontSize}rem`;
+  };
+
+  const decreaseFont = () => {
+    focusFontSize = Math.max(0.5, focusFontSize - 0.1);
+    if (focusContent) focusContent.style.fontSize = `${focusFontSize}rem`;
+  };
+
+  if (focusBtn) focusBtn.addEventListener("click", openFocusModal);
+  if (closeFocusBtn) closeFocusBtn.addEventListener("click", closeFocusModal);
+  if (increaseFontBtn) increaseFontBtn.addEventListener("click", increaseFont);
+  if (decreaseFontBtn) decreaseFontBtn.addEventListener("click", decreaseFont);
+  if (focusModal)
+    window.addEventListener("click", (e) => {
+      if (e.target === focusModal) closeFocusModal();
+    });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeFocusModal();
+  });
+
   // Save or update build depending on context
   safeAdd("saveBuildButton", "click", async () => {
     const buildId = getCurrentBuildId();

--- a/src/js/modules/modal.js
+++ b/src/js/modules/modal.js
@@ -478,6 +478,7 @@ export function closeModal() {
   if (!modal) return;
 
   modal.style.display = "none";
+  document.body.classList.remove("modal-open");
 
   // 🔄 Reset filters
   const allCategories = document.querySelectorAll(
@@ -512,6 +513,7 @@ export function openModal(modalId) {
   const modal = document.getElementById(modalId);
   if (modal) {
     modal.style.display = "block";
+    document.body.classList.add("modal-open");
   } else {
     console.error(`Modal with ID "${modalId}" not found.`);
   }

--- a/src/js/modules/viewBuild.js
+++ b/src/js/modules/viewBuild.js
@@ -58,11 +58,13 @@ function openFocusModal() {
     if (btn) btn.remove();
     focusContent.style.fontSize = `${focusFontSize}rem`;
   }
+  document.body.classList.add("modal-open");
   focusModal.style.display = "block";
 }
 
 function closeFocusModal() {
   if (focusModal) focusModal.style.display = "none";
+  document.body.classList.remove("modal-open");
 }
 
 function increaseFont() {

--- a/src/js/modules/viewBuild.js
+++ b/src/js/modules/viewBuild.js
@@ -54,6 +54,8 @@ function openFocusModal() {
   const buildOrder = document.getElementById("buildOrder");
   if (buildOrder) {
     focusContent.innerHTML = buildOrder.innerHTML;
+    const btn = focusContent.querySelector("#openFocusModal");
+    if (btn) btn.remove();
     focusContent.style.fontSize = `${focusFontSize}rem`;
   }
   focusModal.style.display = "block";

--- a/src/js/modules/viewBuild.js
+++ b/src/js/modules/viewBuild.js
@@ -28,6 +28,13 @@ const pageBackButton = document.getElementById("pageBackButton");
 const ratingItem = document.getElementById("ratingItem");
 const infoGrid = document.querySelector(".build-info-grid");
 const mainLayout = document.querySelector(".main-layout");
+let focusBtn = document.getElementById("openFocusModal");
+let focusModal = document.getElementById("focusModal");
+let closeFocusBtn = document.getElementById("closeFocusModal");
+let increaseFontBtn = document.getElementById("increaseFontBtn");
+let decreaseFontBtn = document.getElementById("decreaseFontBtn");
+let focusContent = document.getElementById("focusContent");
+let focusFontSize = 1;
 
 function adjustRatingPosition() {
   if (!ratingItem || !infoGrid || !mainLayout) return;
@@ -40,6 +47,30 @@ function adjustRatingPosition() {
       infoGrid.appendChild(ratingItem);
     }
   }
+}
+
+function openFocusModal() {
+  if (!focusModal || !focusContent) return;
+  const buildOrder = document.getElementById("buildOrder");
+  if (buildOrder) {
+    focusContent.innerHTML = buildOrder.innerHTML;
+    focusContent.style.fontSize = `${focusFontSize}rem`;
+  }
+  focusModal.style.display = "block";
+}
+
+function closeFocusModal() {
+  if (focusModal) focusModal.style.display = "none";
+}
+
+function increaseFont() {
+  focusFontSize = Math.min(3, focusFontSize + 0.1);
+  if (focusContent) focusContent.style.fontSize = `${focusFontSize}rem`;
+}
+
+function decreaseFont() {
+  focusFontSize = Math.max(0.5, focusFontSize - 0.1);
+  if (focusContent) focusContent.style.fontSize = `${focusFontSize}rem`;
 }
 
 function handleBackClick(e) {
@@ -602,6 +633,25 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   adjustRatingPosition();
   window.addEventListener("resize", adjustRatingPosition);
+
+  focusBtn = document.getElementById("openFocusModal");
+  focusModal = document.getElementById("focusModal");
+  closeFocusBtn = document.getElementById("closeFocusModal");
+  increaseFontBtn = document.getElementById("increaseFontBtn");
+  decreaseFontBtn = document.getElementById("decreaseFontBtn");
+  focusContent = document.getElementById("focusContent");
+
+  if (focusBtn) focusBtn.addEventListener("click", openFocusModal);
+  if (closeFocusBtn) closeFocusBtn.addEventListener("click", closeFocusModal);
+  if (increaseFontBtn) increaseFontBtn.addEventListener("click", increaseFont);
+  if (decreaseFontBtn) decreaseFontBtn.addEventListener("click", decreaseFont);
+  if (focusModal)
+    window.addEventListener("click", (e) => {
+      if (e.target === focusModal) closeFocusModal();
+    });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") closeFocusModal();
+  });
 
   const importBtn = document.getElementById("importBuildButton");
 

--- a/viewBuild.html
+++ b/viewBuild.html
@@ -77,6 +77,9 @@
         <img src="./img/SVG/back.svg" alt="Back" />
       </a>
       <h1 id="buildTitle">Loading...</h1>
+      <button id="openFocusModal" class="focus-btn" title="Focus Mode">
+        <img src="./img/SVG/expand-top-right-svgrepo-com.svg" alt="Focus" />
+      </button>
     </div>
 
     <!-- Build Info Grid -->
@@ -192,6 +195,17 @@
 
   </div>
 
+  <!-- Focus Modal for build output -->
+  <div id="focusModal" class="modal fullscreen-modal">
+    <div class="modal-content">
+      <span class="close-modal" id="closeFocusModal">&times;</span>
+      <div class="font-controls">
+        <button id="increaseFontBtn">A+</button>
+        <button id="decreaseFontBtn">A-</button>
+      </div>
+      <div id="focusContent" class="focus-content"></div>
+    </div>
+  </div>
 
   <script type="module">
     import { initializeAuthUI } from './src/app.js';

--- a/viewBuild.html
+++ b/viewBuild.html
@@ -196,7 +196,7 @@
   </div>
 
   <!-- Focus Modal for build output -->
-  <div id="focusModal" class="modal fullscreen-modal">
+  <div id="focusModal" class="modal">
     <div class="modal-content">
       <span class="close-modal" id="closeFocusModal">&times;</span>
       <div class="font-controls">


### PR DESCRIPTION
## Summary
- add button to enter focus mode on build pages
- create fullscreen modal with font-size controls
- hook up focus mode behaviour in JS
- update version number to 0.5.8073

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68628af9d790832ab5a4e2baa16a01bb