### PR TITLE
Add game selector placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,12 @@
   </div>
   <div id="toast-container"></div>
 
+  <!-- Game Selector Placeholder -->
+  <div id="game-selector">
+    <button id="sc2Btn" class="game-option active">StarCraft 2</button>
+    <button id="sgBtn" class="game-option coming-soon" disabled title="Coming Soon">Stormgate</button>
+  </div>
+
   <!-- Auth Container -->
   <div id="auth-container">
     <div class="auth-info">
@@ -821,7 +827,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8085</p>
+      <p>Version 0.5.8086</p>
 
 
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -142,6 +142,41 @@ body {
   border: 2px solid transparent;
 }
 
+/* Game Selector Placeholder */
+#game-selector {
+  position: fixed;
+  top: 10px;
+  right: 170px;
+  background-color: #37373780;
+  padding: 8px 15px;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 999;
+  backdrop-filter: blur(5px);
+}
+
+.game-option {
+  background: none;
+  color: #fff;
+  border: 1px solid #555;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.game-option.active {
+  border-color: limegreen;
+}
+
+.game-option.coming-soon {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 #userInfo {
   display: none;
 }
@@ -4668,6 +4703,10 @@ button.btn-small {
     top: 10px;
     right: 10px;
     width: fit-content;
+  }
+  #game-selector {
+    top: 10px;
+    right: 160px;
   }
   #userName {
     display: none;


### PR DESCRIPTION
## Summary
- add placeholder UI for selecting game left of auth container
- bump version to 0.5.8086

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862f105c8bc832a900fc85cd1546894