### PR TITLE
Add placeholder game selector dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -838,7 +838,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8086</p>
+      <p>Version 0.5.8087</p>
 
 
 

--- a/index.html
+++ b/index.html
@@ -39,6 +39,23 @@
   </div>
   <div id="toast-container"></div>
 
+  <!-- Game Selector -->
+  <div id="game-select">
+    <div class="selected-game">
+      <img src="img/game-icons/sc2.svg" alt="StarCraft 2" />
+    </div>
+    <div class="game-dropdown">
+      <div class="game-option active">
+        <img src="img/game-icons/sc2.svg" alt="StarCraft 2" />
+        <span>StarCraft 2</span>
+      </div>
+      <div class="game-option disabled">
+        <img src="img/game-icons/stormgate.svg" alt="Stormgate" />
+        <span>Stormgate (Coming Soon)</span>
+      </div>
+    </div>
+  </div>
+
   <!-- Auth Container -->
   <div id="auth-container">
     <div class="auth-info">
@@ -821,7 +838,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8085</p>
+      <p>Version 0.5.8086</p>
 
 
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -157,6 +157,60 @@ body {
   border: 0;
 }
 
+/* Game Selector */
+#game-select {
+  position: fixed;
+  top: 10px;
+  right: 120px;
+  background-color: #37373780;
+  padding: 6px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: 999;
+}
+
+#game-select .selected-game img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#game-select .game-dropdown {
+  display: none;
+  position: absolute;
+  top: 48px;
+  left: 0;
+  background-color: #37373780;
+  padding: 5px;
+  border-radius: 8px;
+}
+
+#game-select:hover .game-dropdown {
+  display: block;
+}
+
+#game-select .game-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px;
+}
+
+#game-select .game-option img {
+  width: 30px;
+  height: 30px;
+  border-radius: 4px;
+}
+
+#game-select .game-option.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .dropdown {
   position: relative;
   display: inline-block;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -163,7 +163,6 @@ body {
   top: 10px;
   right: 120px;
   background-color: #37373780;
-  padding: 6px;
   border-radius: 8px;
   display: flex;
   flex-direction: column;
@@ -172,8 +171,8 @@ body {
 }
 
 #game-select .selected-game img {
-  width: 40px;
-  height: 40px;
+  width: 60px;
+  height: 60px;
   object-fit: cover;
   border-radius: 4px;
   cursor: pointer;
@@ -187,6 +186,8 @@ body {
   background-color: #37373780;
   padding: 5px;
   border-radius: 8px;
+  min-width: 210px;
+  white-space: nowrap;
 }
 
 #game-select:hover .game-dropdown {

--- a/public/img/game-icons/sc2.svg
+++ b/public/img/game-icons/sc2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+  <rect width="50" height="50" fill="#0b152d" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="18" fill="#ffffff">SC2</text>
+</svg>

--- a/public/img/game-icons/stormgate.svg
+++ b/public/img/game-icons/stormgate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50">
+  <rect width="50" height="50" fill="#442" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="16" fill="#ffffff">SG</text>
+</svg>


### PR DESCRIPTION
## Summary
- add game selector placeholder next to auth container
- include placeholder icons for SC2 and Stormgate
- bump version number

## Testing
- `npm run lint` *(fails: Missing script)*
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6866956b2e80832a84a6d46dee55ca17