### PR TITLE
Add hallucination tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -568,18 +568,25 @@ def upload():
 
             # ✅ Safe hallucination cast detection
             if hasattr(event, "ability_name") and event.ability_name:
-                ability_name = event.ability_name.lower()
-                if "hallucination" in ability_name:
+                ability_name = event.ability_name
+                ability_lower = ability_name.lower()
+                if "hallucination" in ability_lower or "hallucinate" in ability_lower:
                     last_hallucination_frame = event.frame
                     last_hallucination_pid = event.pid
 
-                    # NEW: push expected illusion type(s)
-                    if "phoenix" in ability_name:
-                        pending_hallucinations.append({
-                            "type": "Phoenix",
-                            "frame": event.frame,
-                            "pid": event.pid
-                        })
+                    m = re.search(
+                        r"hallucinat(?:e|ion)[^A-Za-z]*([A-Za-z]+)", ability_name, re.I
+                    )
+                    if m:
+                        unit_raw = m.group(1)
+                        unit_formatted = format_name(unit_raw)
+                        count = 2 if unit_formatted.lower() == "phoenix" else 1
+                        for _ in range(count):
+                            pending_hallucinations.append({
+                                "type": unit_formatted,
+                                "frame": event.frame,
+                                "pid": event.pid,
+                            })
 
 
 
@@ -640,6 +647,7 @@ def upload():
                             break
 
                 if hallucinated:
+                    event.unit.is_hallucination = True
                     name += " (hallucination)"
 
                 name = tidy(name)
@@ -724,6 +732,7 @@ def upload():
                             break
 
                 if hallucinated:
+                    event.unit.is_hallucination = True
                     name += " (hallucination)"
 
                 name = tidy(name)

--- a/index.html
+++ b/index.html
@@ -838,7 +838,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8087</p>
+      <p>Version 0.5.8088</p>
 
 
 


### PR DESCRIPTION
## Summary
- robust hallucination detection via ability events
- mark born and init units matched within 100 frames
- bump footer version

## Testing
- `python -m py_compile app.py name_map.py`

------
https://chatgpt.com/codex/tasks/task_e_686c2c094c5c832a881ed867843b8b6e