### PR TITLE
Add exclude units option

### DIFF
--- a/app.py
+++ b/app.py
@@ -478,6 +478,8 @@ def upload():
         # ----- flags ------------------------------------------------
         exclude_flag = request.form.get('exclude_workers', '')
         exclude_workers = str(exclude_flag).lower() in {'1', 'true', 'yes', 'on'}
+        exclude_units_flag = request.form.get('exclude_units', '')
+        exclude_units = str(exclude_units_flag).lower() in {'1', 'true', 'yes', 'on'}
         exclude_supply_flag = request.form.get('exclude_supply', '')
         exclude_supply = str(exclude_supply_flag).lower() in {'1', 'true', 'yes', 'on'}
         exclude_time_flag = request.form.get('exclude_time', '')
@@ -645,6 +647,8 @@ def upload():
                     continue
                 unit = event.unit
                 if getattr(unit, "is_building", False):
+                    continue
+                if exclude_units:
                     continue
 
                 name = format_name(event.unit_type_name)

--- a/index.html
+++ b/index.html
@@ -768,6 +768,15 @@
           </div>
         </div>
         <div class="publish-checkbox-row">
+          <span>Exclude Units</span>
+          <div class="checkbox-wrapper-59">
+            <label class="switch">
+              <input type="checkbox" id="excludeUnitsCheckbox" />
+              <span class="slider"></span>
+            </label>
+          </div>
+        </div>
+        <div class="publish-checkbox-row">
           <span>Exclude Supply</span>
           <div class="checkbox-wrapper-59">
             <label class="switch">
@@ -841,7 +850,7 @@
     <div class="footer-center" id="site-info">
 
 
-      <p>Version 0.5.8096</p>
+      <p>Version 0.5.8097</p>
 
 
 

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -603,6 +603,9 @@ export async function initializeIndexPage() {
     if (document.getElementById("excludeWorkersCheckbox")?.checked) {
       formData.append("exclude_workers", "1");
     }
+    if (document.getElementById("excludeUnitsCheckbox")?.checked) {
+      formData.append("exclude_units", "1");
+    }
     if (document.getElementById("excludeSupplyCheckbox")?.checked) {
       formData.append("exclude_supply", "1");
     }


### PR DESCRIPTION
## Summary
- allow filtering units when parsing replays
- wire checkbox value to the parser API
- bump site version to 0.5.8097

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d8bcc49bc832ab94f5cf217457a28