### PR TITLE
Fix exclude units filter

### DIFF
--- a/app.py
+++ b/app.py
@@ -739,6 +739,10 @@ def upload():
                 if event.control_pid != player.pid:
                     continue
 
+                unit = event.unit
+                if not getattr(unit, "is_building", False) and exclude_units:
+                    continue
+
                 name = format_name(event.unit_type_name)
 
                 # Robust fallback: match known pending illusions

--- a/index.html
+++ b/index.html
@@ -849,7 +849,7 @@
     </div>
     <div class="footer-center" id="site-info">
 
-      <p>Version 0.5.8098</p>
+      <p>Version 0.5.8099</p>
 
 
     </div>


### PR DESCRIPTION
## Summary
- ensure `exclude units` also filters unit init events
- bump version number in `index.html`

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686d91031270832a88d9c8c08084a846