### PR TITLE
Update Build Order Help with base indicator example

### DIFF
--- a/index.html
+++ b/index.html
@@ -853,7 +853,7 @@
     </div>
     <div class="footer-center" id="site-info">
 
-      <p>Version 0.5.8102</p>
+      <p>Version 0.5.8103</p>
 
 
     </div>

--- a/src/js/modules/uiHandlers.js
+++ b/src/js/modules/uiHandlers.js
@@ -477,6 +477,13 @@ export function showBuildOrderHelpModal() {
     `,
     },
     {
+      id: "base-indicator",
+      title: "Base Production Indicator",
+      input: "queen (b1)",
+      description:
+        "Append <code>(b1)</code>, <code>(b2)</code>, and so on after a unit or structure to mark the base where it is produced.",
+    },
+    {
       id: "quick-typing",
       title: "Quick Typing",
       image: "./img/info/quick_typing.webp",


### PR DESCRIPTION
## Summary
- explain the new base indicator `(b1)` feature in the Build Order help
- bump version to 0.5.8103

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fad93c014832a915a25377abea1dd