### PR TITLE
Implement publisher chip redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -853,7 +853,7 @@
     </div>
     <div class="footer-center" id="site-info">
 
-      <p>Version 0.5.8109</p>
+      <p>Version 0.5.8110</p>
 
 
     </div>

--- a/index.html
+++ b/index.html
@@ -853,7 +853,7 @@
     </div>
     <div class="footer-center" id="site-info">
 
-      <p>Version 0.5.8108</p>
+      <p>Version 0.5.8109</p>
 
 
     </div>

--- a/src/js/modules/viewBuild.js
+++ b/src/js/modules/viewBuild.js
@@ -709,6 +709,23 @@ document.addEventListener("DOMContentLoaded", async () => {
   // ✅ Load build data after DOM ready
   await loadBuild();
 
+  // Redirect to community builds when clicking publisher name
+  document.querySelectorAll('.publisher-chip').forEach((chip) => {
+    chip.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const name =
+        document.getElementById('buildPublisher')?.innerText ||
+        document.getElementById('buildPublisherMobile')?.innerText ||
+        '';
+      if (!name) return;
+      localStorage.setItem('restoreCommunityModal', 'true');
+      localStorage.removeItem('communityFilterType');
+      localStorage.removeItem('communityFilterValue');
+      localStorage.setItem('communitySearchQuery', name);
+      window.location.href = 'index.html';
+    });
+  });
+
   // Update vote UI when auth state changes (e.g., after sign-in)
   auth.onAuthStateChanged(() => {
     const buildId = getBuildIdFromPath();


### PR DESCRIPTION
## Summary
- clicking the publisher chip on a build now redirects back to the Community Builds modal and searches for that publisher
- bump version to 0.5.8109

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871179ae5d8832ab9851a8db52209fa