### PR TITLE
Update ravager & lurker morph parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -853,7 +853,7 @@
     </div>
     <div class="footer-center" id="site-info">
 
-      <p>Version 0.5.8110</p>
+      <p>Version 0.5.8111</p>
 
 
     </div>


### PR DESCRIPTION
## Summary
- handle Ravager and Lurker morph abilities
- ignore Ravager/Lurker UnitBorn events
- bump site version to 0.5.8111

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6871492ba938832a830e7f292dca92c5