### PR TITLE
Ensure prerender uses absolute URL and build data

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -23,8 +23,7 @@
         "source": "/build/:matchup/:slug/:id",
         "function": "servePreRenderedBuild"
       },
-      { "source": "/build/:id", "function": "servePreRenderedBuild" },
-      { "source": "/viewBuild.html", "function": "servePreRenderedBuild" }
+      { "source": "/build/:id", "function": "servePreRenderedBuild" }
     ]
   },
   "emulators": {

--- a/functions/index.js
+++ b/functions/index.js
@@ -8,7 +8,8 @@ admin.initializeApp();
 const bucket = admin.storage().bucket();
 
 // Your site URL
-const SITE_URL = "/viewBuild.html"; // relative path
+const SITE_URL =
+  process.env.SITE_URL || "https://z-build-order.web.app/viewBuild.html"; // absolute path
 
 // Common crawler user-agents
 const BOT_USER_AGENTS = [
@@ -31,8 +32,12 @@ function isBot(userAgent) {
 exports.renderNewBuild = onDocumentCreated(
   "publishedBuilds/{buildId}",
   async (event) => {
-    const buildData = event.data;
     const buildId = event.params.buildId;
+    const buildData = event.data.data();
+    if (!buildData) {
+      console.warn("No build data available, skipping prerender for", buildId);
+      return null;
+    }
 
     console.log("🚀 Pre-rendering build:", buildId);
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "functions",
       "dependencies": {
+        "@sparticuz/chromium": "^140.0.0",
+        "dompurify": "^3.2.7",
         "firebase-admin": "^12.7.0",
         "firebase-functions": "^5.1.1",
         "puppeteer": "^24.23.0"
@@ -1540,6 +1542,19 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@sparticuz/chromium": {
+      "version": "140.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-140.0.0.tgz",
+      "integrity": "sha512-pDyHiSp+buakpUq23b74JPC9T5M58665y6ULlh8uSuIDK0vxVGyLzjTTigQL202c6+0+NNp1Po5rgWcT7JSO5g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "tar-fs": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1814,6 +1829,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
     },
@@ -3172,6 +3194,15 @@
       "integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3806,6 +3837,26 @@
         "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
         "firebase-functions": ">=4.9.0",
         "jest": ">=28.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/foreground-child": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,8 @@
   },
   "main": "index.js",
   "dependencies": {
+    "@sparticuz/chromium": "^140.0.0",
+    "dompurify": "^3.2.7",
     "firebase-admin": "^12.7.0",
     "firebase-functions": "^5.1.1",
     "puppeteer": "^24.23.0"

--- a/index.html
+++ b/index.html
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 1.0.0</p>
+      <p>Version 0.5.0001</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/index.html
+++ b/index.html
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 0.5.0002</p>
+      <p>Version 0.5.0003</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/index.html
+++ b/index.html
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 0.5.0001</p>
+      <p>Version 0.5.0002</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/src/js/modules/viewBuild.js
+++ b/src/js/modules/viewBuild.js
@@ -132,6 +132,12 @@ async function incrementBuildViews(buildId) {
 }
 
 function getBuildIdFromPath() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const queryId = searchParams.get("id");
+  if (queryId) {
+    return decodeURIComponent(queryId);
+  }
+
   const parts = window.location.pathname.split("/").filter(Boolean);
   let id = parts[parts.length - 1] || "";
   if (id.includes("-")) id = id.split("-").pop();


### PR DESCRIPTION
## Summary
- switch the prerendered view URL to an absolute origin with optional configuration override
- convert the Firestore snapshot to raw build data and skip prerendering when absent
- bump the site footer version indicator to 0.5.0001

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e06080cae0832a8a0a5e19731fcbbe