### PR TITLE
Fix prerendered build handling for crawlers

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,11 +19,7 @@
     ],
     "rewrites": [
       { "source": "/sitemap.xml", "function": "sitemap" },
-      {
-        "source": "/build/:matchup/:slug/:id",
-        "function": "servePreRenderedBuild"
-      },
-      { "source": "/build/:id", "function": "servePreRenderedBuild" }
+      { "source": "/build/**", "function": "servePreRenderedBuild" }
     ]
   },
   "emulators": {

--- a/firebase.json
+++ b/firebase.json
@@ -19,7 +19,8 @@
     ],
     "rewrites": [
       { "source": "/sitemap.xml", "function": "sitemap" },
-      { "source": "/build/**", "function": "servePreRenderedBuild" }
+      { "source": "/build/:matchup/:slug/:id", "function": "servePreRenderedBuild" },
+      { "source": "/build/:id", "function": "servePreRenderedBuild" }
     ]
   },
   "emulators": {

--- a/firebase.json
+++ b/firebase.json
@@ -15,12 +15,30 @@
             "value": "same-origin-allow-popups"
           }
         ]
+      },
+      {
+        "source": "/build/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-store, must-revalidate"
+          }
+        ]
       }
     ],
     "rewrites": [
-      { "source": "/sitemap.xml", "function": "sitemap" },
-      { "source": "/build/:matchup/:slug/:id", "function": "servePreRenderedBuild" },
-      { "source": "/build/:id", "function": "servePreRenderedBuild" }
+      {
+        "source": "/build/**",
+        "function": "servePreRenderedBuild"
+      },
+      {
+        "source": "/sitemap.xml",
+        "function": "sitemap"
+      },
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
     ]
   },
   "emulators": {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,18 +1,22 @@
 // functions/index.js
-const { onDocumentCreated } = require("firebase-functions/v2/firestore");
+const { onDocumentWritten } = require("firebase-functions/v2/firestore");
 const { onRequest } = require("firebase-functions/v2/https");
 const admin = require("firebase-admin");
 const chromium = require("@sparticuz/chromium");
 const puppeteer = require("puppeteer");
+const { JSDOM } = require("jsdom");
+const createDOMPurify = require("dompurify");
 
 admin.initializeApp();
 const bucket = admin.storage().bucket();
+const firestore = admin.firestore();
 
-// Your site URL
+const window = new JSDOM("").window;
+const DOMPurify = createDOMPurify(window);
+
 const SITE_URL =
-  process.env.SITE_URL || "https://z-build-order.web.app/viewBuild.html"; // absolute path
+  process.env.SITE_URL || "https://z-build-order.web.app/viewBuild.html";
 
-// Common crawler user-agents
 const BOT_USER_AGENTS = [
   /googlebot/i,
   /bingbot/i,
@@ -23,22 +27,209 @@ const BOT_USER_AGENTS = [
   /linkedinbot/i,
 ];
 
-function isBot(userAgent) {
+const PRERENDER_TIMEOUT_MS = 60_000;
+const SELECTORS_TO_WAIT = ["#buildTitle", "#buildPublisher", "#buildOrder"];
+
+const CHROMIUM_ARGS = [
+  ...chromium.args,
+  "--no-sandbox",
+  "--disable-setuid-sandbox",
+  "--disable-dev-shm-usage",
+];
+
+function isBot(userAgent = "") {
   return BOT_USER_AGENTS.some((regex) => regex.test(userAgent));
 }
 
-/**
- * Firestore trigger: pre-render new builds (v6+ modular)
- */
-const { onDocumentWritten } = require("firebase-functions/v2/firestore");
+function sanitizeText(value, fallback) {
+  const base = value == null ? "" : String(value);
+  const sanitized = DOMPurify.sanitize(base, {
+    ALLOWED_TAGS: [],
+    ALLOWED_ATTR: [],
+  }).trim();
+  return sanitized || fallback;
+}
 
-// Firestore trigger: pre-render builds on create or update
+function buildMetaStrings(buildData) {
+  const sanitizedTitle = sanitizeText(buildData.title, "Untitled build");
+  const sanitizedPublisher = sanitizeText(
+    buildData.publisher,
+    "Anonymous"
+  );
+  const sanitizedSubcategory = sanitizeText(
+    buildData.subcategory,
+    "Unknown"
+  );
+
+  return {
+    pageTitle: sanitizeText(
+      `Z-Build Order – ${sanitizedTitle}`,
+      "Z-Build Order"
+    ),
+    description: sanitizeText(
+      `StarCraft 2 build order by ${sanitizedPublisher}, matchup: ${sanitizedSubcategory}`,
+      "StarCraft 2 build order"
+    ),
+    ogTitle: sanitizeText(
+      `Z-Build Order – ${sanitizedTitle}`,
+      "Z-Build Order"
+    ),
+    ogDescription: sanitizeText(
+      `Build order for ${sanitizedSubcategory}`,
+      "StarCraft 2 build order"
+    ),
+    ogSiteName: sanitizedPublisher,
+  };
+}
+
+async function waitForSelectorWithWarning(page, selector, buildId) {
+  try {
+    await page.waitForSelector(selector, { timeout: 10_000 });
+  } catch (err) {
+    console.warn(
+      `⚠️ Selector ${selector} not found within timeout for build ${buildId}:`,
+      err.message
+    );
+  }
+}
+
+async function launchBrowser() {
+  return puppeteer.launch({
+    args: CHROMIUM_ARGS,
+    defaultViewport: chromium.defaultViewport,
+    executablePath: await chromium.executablePath(),
+    headless: chromium.headless,
+    ignoreHTTPSErrors: true,
+  });
+}
+
+async function fetchBuildData(buildId) {
+  const snapshot = await firestore
+    .collection("publishedBuilds")
+    .doc(buildId)
+    .get();
+
+  if (!snapshot.exists) {
+    return null;
+  }
+
+  return snapshot.data();
+}
+
+async function captureBuildHtml(buildId, buildDataFromEvent) {
+  const buildData = buildDataFromEvent || (await fetchBuildData(buildId));
+
+  if (!buildData) {
+    throw new Error(`No build data found for ${buildId}`);
+  }
+
+  const meta = buildMetaStrings(buildData);
+  const browser = await launchBrowser();
+  let page;
+
+  try {
+    page = await browser.newPage();
+    await page.setCacheEnabled(false);
+    await page.setDefaultNavigationTimeout(PRERENDER_TIMEOUT_MS);
+    await page.setDefaultTimeout(PRERENDER_TIMEOUT_MS / 4);
+
+    await page.setRequestInterception(true);
+    page.on("request", (request) => {
+      try {
+        const resourceType = request.resourceType();
+        if (["image", "media", "font"].includes(resourceType)) {
+          request.abort();
+        } else {
+          request.continue();
+        }
+      } catch (err) {
+        console.warn(
+          `⚠️ Request interception failed for ${request.url?.() || "unknown URL"}:`,
+          err.message
+        );
+      }
+    });
+
+    const targetUrl = `${SITE_URL}?id=${encodeURIComponent(buildId)}`;
+    await page.goto(targetUrl, { waitUntil: "networkidle0", timeout: PRERENDER_TIMEOUT_MS });
+
+    for (const selector of SELECTORS_TO_WAIT) {
+      await waitForSelectorWithWarning(page, selector, buildId);
+    }
+
+    await page.evaluate((metaInfo) => {
+      const head = document.head || document.querySelector("head");
+      if (!head) {
+        return;
+      }
+
+      const removeIfExists = (selector) => {
+        const existing = head.querySelector(selector);
+        if (existing) {
+          existing.remove();
+        }
+      };
+
+      document.title = metaInfo.pageTitle;
+
+      removeIfExists('meta[name="description"]');
+      const description = document.createElement("meta");
+      description.name = "description";
+      description.content = metaInfo.description;
+      head.appendChild(description);
+
+      removeIfExists('meta[property="og:title"]');
+      const ogTitle = document.createElement("meta");
+      ogTitle.setAttribute("property", "og:title");
+      ogTitle.content = metaInfo.ogTitle;
+      head.appendChild(ogTitle);
+
+      removeIfExists('meta[property="og:description"]');
+      const ogDescription = document.createElement("meta");
+      ogDescription.setAttribute("property", "og:description");
+      ogDescription.content = metaInfo.ogDescription;
+      head.appendChild(ogDescription);
+
+      removeIfExists('meta[property="og:site_name"]');
+      const ogSiteName = document.createElement("meta");
+      ogSiteName.setAttribute("property", "og:site_name");
+      ogSiteName.content = metaInfo.ogSiteName;
+      head.appendChild(ogSiteName);
+    }, meta);
+
+    const html = await page.content();
+    return html;
+  } finally {
+    if (page) {
+      await page.close().catch(() => {});
+    }
+    await browser.close().catch(() => {});
+  }
+}
+
+async function saveHtmlToStorage(buildId, html) {
+  const file = bucket.file(`preRenderedBuilds/${buildId}.html`);
+  await file.save(html, {
+    contentType: "text/html",
+    metadata: {
+      cacheControl: "public, max-age=86400",
+    },
+  });
+  return file;
+}
+
+async function renderAndStoreBuild(buildId, buildDataFromEvent) {
+  const html = await captureBuildHtml(buildId, buildDataFromEvent);
+  await saveHtmlToStorage(buildId, html);
+  return html;
+}
+
 exports.renderNewBuild = onDocumentWritten(
   {
     document: "publishedBuilds/{buildId}",
     region: "us-central1",
-    memory: "1GiB", // 👈 bump memory
-    timeoutSeconds: 120, // 👈 optional: allow longer Puppeteer runs
+    memory: "1GiB",
+    timeoutSeconds: 120,
   },
   async (event) => {
     const buildId = event.params.buildId;
@@ -46,148 +237,72 @@ exports.renderNewBuild = onDocumentWritten(
 
     if (!buildData) {
       console.warn(
-        "❌ No build data available (deleted?), skipping prerender for",
-        buildId
+        `❌ No build data available (deleted?), skipping prerender for ${buildId}`
       );
       return null;
     }
 
     console.log("🚀 Pre-rendering build:", buildId);
 
-    const browser = await puppeteer.launch({
-      args: chromium.args,
-      defaultViewport: chromium.defaultViewport,
-      executablePath: await chromium.executablePath(),
-      headless: chromium.headless,
-      ignoreHTTPSErrors: true,
-    });
-    const page = await browser.newPage();
-
-    const url = `${SITE_URL}?id=${buildId}`;
-    await page.goto(url, { waitUntil: "networkidle0" });
-
-    const waitForSelectorWithWarning = async (selector, timeout = 10000) => {
-      try {
-        await page.waitForSelector(selector, { timeout });
-      } catch (err) {
-        console.warn(
-          `⚠️ Selector ${selector} not found within ${timeout}ms for build ${buildId}:`,
-          err.message
-        );
-      }
-    };
-
-    // Wait for SPA to populate the main build data
-    await waitForSelectorWithWarning("#buildTitle");
-    await waitForSelectorWithWarning("#buildPublisher");
-    await waitForSelectorWithWarning("#buildOrder");
-
     try {
-      await page.addScriptTag({
-        url: "https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.3/purify.min.js",
-      });
-    } catch (err) {
-      console.warn(
-        "⚠️ Failed to load DOMPurify for sanitization:",
-        err.message
-      );
+      await renderAndStoreBuild(buildId, buildData);
+      console.log("✅ Pre-rendered HTML saved for build:", buildId);
+    } catch (error) {
+      console.error(`❌ Failed to pre-render build ${buildId}:`, error);
     }
 
-    // Inject SEO meta tags dynamically
-    await page.evaluate((data) => {
-      const head = document.querySelector("head");
-      if (!head || typeof DOMPurify === "undefined") {
-        console.warn("⚠️ DOMPurify not available or head element missing");
-        return;
-      }
-
-      const sanitizedTitle = DOMPurify.sanitize(data.title || "Untitled build");
-      const sanitizedPublisher = DOMPurify.sanitize(
-        data.publisher || "Anonymous"
-      );
-      const sanitizedSubcategory = DOMPurify.sanitize(
-        data.subcategory || "Unknown"
-      );
-
-      // Title
-      const titleTag = document.createElement("title");
-      titleTag.textContent = `Z-Build Order – ${sanitizedTitle}`;
-      head.appendChild(titleTag);
-
-      // Meta description
-      const descTag = document.createElement("meta");
-      descTag.name = "description";
-      descTag.content = `StarCraft 2 build order by ${sanitizedPublisher}, matchup: ${sanitizedSubcategory}`;
-      head.appendChild(descTag);
-
-      // Open Graph tags
-      const ogTitle = document.createElement("meta");
-      ogTitle.setAttribute("property", "og:title");
-      ogTitle.content = `Z-Build Order – ${sanitizedTitle}`;
-      head.appendChild(ogTitle);
-
-      const ogDesc = document.createElement("meta");
-      ogDesc.setAttribute("property", "og:description");
-      ogDesc.content = `Build order for ${sanitizedSubcategory}`;
-      head.appendChild(ogDesc);
-
-      const ogPublisher = document.createElement("meta");
-      ogPublisher.setAttribute("property", "og:site_name");
-      ogPublisher.content = sanitizedPublisher;
-      head.appendChild(ogPublisher);
-    }, buildData);
-
-    const html = await page.content();
-    const file = bucket.file(`preRenderedBuilds/${buildId}.html`);
-    await file.save(html, { contentType: "text/html" });
-
-    console.log("✅ Pre-rendered HTML saved for build:", buildId);
-
-    await browser.close();
     return null;
   }
 );
 
-/**
- * HTTPS function: serve pre-rendered builds to crawlers (v6+)
- */
-exports.servePreRenderedBuild = onRequest(async (req, res) => {
-  let buildId = req.query.id;
+exports.servePreRenderedBuild = onRequest(
+  {
+    region: "us-central1",
+    memory: "1GiB",
+    timeoutSeconds: 120,
+  },
+  async (req, res) => {
+    let buildId = req.query.id;
 
-  // If no query param, try extracting from path
-  if (!buildId && req.path) {
-    const parts = req.path.split("/").filter(Boolean); // remove empty segments
-    buildId = parts[parts.length - 1]; // last segment is usually the build ID
-  }
+    if (!buildId && req.path) {
+      const parts = req.path.split("/").filter(Boolean);
+      buildId = parts[parts.length - 1];
+    }
 
-  if (!buildId) {
-    res.status(400).send("Build ID missing.");
-    return;
-  }
-
-  const userAgent = req.headers["user-agent"] || "";
-
-  if (!isBot(userAgent)) {
-    res.redirect(302, `/viewBuild.html?id=${buildId}`);
-    return;
-  }
-
-  try {
-    const file = bucket.file(`preRenderedBuilds/${buildId}.html`);
-    const [exists] = await file.exists();
-
-    if (!exists) {
-      res.redirect(302, `/viewBuild.html?id=${buildId}`);
+    if (!buildId) {
+      res.status(400).send("Build ID missing.");
       return;
     }
 
-    const [contents] = await file.download();
-    res.set("Content-Type", "text/html");
-    res.set("Cache-Control", "public, max-age=300, s-maxage=600");
+    const userAgent = req.headers["user-agent"] || "";
 
-    res.status(200).send(contents.toString("utf-8"));
-  } catch (err) {
-    console.error("Error serving pre-rendered build:", err);
-    res.status(500).send("Internal Server Error");
+    if (!isBot(userAgent)) {
+      res.redirect(302, `/viewBuild.html?id=${encodeURIComponent(buildId)}`);
+      return;
+    }
+
+    res.set("Vary", "User-Agent");
+
+    try {
+      const file = bucket.file(`preRenderedBuilds/${buildId}.html`);
+      const [exists] = await file.exists();
+
+      let html;
+
+      if (exists) {
+        const [contents] = await file.download();
+        html = contents.toString("utf-8");
+      } else {
+        html = await renderAndStoreBuild(buildId);
+      }
+
+      res.set("Content-Type", "text/html; charset=utf-8");
+      res.set("Cache-Control", "public, max-age=300, s-maxage=600");
+
+      res.status(200).send(html);
+    } catch (error) {
+      console.error("Error serving pre-rendered build:", error);
+      res.redirect(302, `/viewBuild.html?id=${encodeURIComponent(buildId)}`);
+    }
   }
-});
+);

--- a/functions/index.js
+++ b/functions/index.js
@@ -380,12 +380,13 @@ exports.servePreRenderedBuild = onRequest(
     const canonicalUrl = buildCanonicalUrl(req);
 
     if (!isBot(userAgent)) {
-      try {
-        await sendSpaIndex(res);
-      } catch (error) {
-        console.error("❌ Failed to serve SPA index:", error);
-        res.status(500).send("Application unavailable.");
-      }
+      const filePath = path.join(process.cwd(), "dist", "viewBuild.html");
+      res.sendFile(filePath, (err) => {
+        if (err) {
+          console.error("Failed to send SPA fallback:", err);
+          res.status(500).send("Application unavailable.");
+        }
+      });
       return;
     }
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,7 +11,7 @@
         "firebase-admin": "^12.7.0",
         "firebase-functions": "^5.1.1",
         "jsdom": "^24.1.3",
-        "puppeteer": "^24.23.0"
+        "puppeteer-core": "^24.23.0"
       },
       "devDependencies": {
         "firebase-functions-test": "^3.1.0"
@@ -43,7 +43,9 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -230,7 +232,9 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2865,7 +2869,9 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3155,50 +3161,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -3512,20 +3474,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -4654,31 +4609,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -4752,7 +4682,9 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -5594,7 +5526,9 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -5729,7 +5663,9 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5913,7 +5849,9 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -6532,23 +6470,13 @@
       "license": "BlueOak-1.0.0",
       "peer": true
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -6658,7 +6586,9 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -6874,27 +6804,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer": {
-      "version": "24.23.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.23.0.tgz",
-      "integrity": "sha512-BVR1Lg8sJGKXY79JARdIssFWK2F6e1j+RyuJP66w4CUmpaXjENicmA3nNpUXA8lcTdDjAndtP+oNdni3T/qQqA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.10.10",
-        "chromium-bidi": "9.1.0",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1508733",
-        "puppeteer-core": "24.23.0",
-        "typed-query-selector": "^2.12.0"
-      },
-      "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/puppeteer-core": {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,6 +10,7 @@
         "dompurify": "^3.2.7",
         "firebase-admin": "^12.7.0",
         "firebase-functions": "^5.1.1",
+        "jsdom": "^24.1.3",
         "puppeteer": "^24.23.0"
       },
       "devDependencies": {
@@ -18,6 +19,25 @@
       "engines": {
         "node": "20"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -599,6 +619,116 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
@@ -2313,8 +2443,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/b4a": {
       "version": "1.7.3",
@@ -2956,7 +3085,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3089,6 +3217,25 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -3096,6 +3243,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -3106,6 +3300,12 @@
       "dependencies": {
         "ms": "2.0.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.0",
@@ -3153,7 +3353,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3301,6 +3500,18 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -3354,7 +3565,6 @@
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -4268,7 +4478,6 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -4289,6 +4498,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/html-entities": {
@@ -4563,6 +4784,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -5384,6 +5611,96 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6019,6 +6336,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6237,6 +6560,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -6510,6 +6845,18 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -6518,6 +6865,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/puppeteer": {
@@ -6615,6 +6971,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6671,6 +7033,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -6721,6 +7089,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6746,6 +7120,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7326,6 +7712,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -7571,6 +7963,21 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -7640,6 +8047,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -7718,6 +8134,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7772,6 +8198,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -7817,6 +8255,39 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -7990,6 +8461,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,6 +17,7 @@
     "dompurify": "^3.2.7",
     "firebase-admin": "^12.7.0",
     "firebase-functions": "^5.1.1",
+    "jsdom": "^24.1.3",
     "puppeteer": "^24.23.0"
   },
   "devDependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,7 @@
     "firebase-admin": "^12.7.0",
     "firebase-functions": "^5.1.1",
     "jsdom": "^24.1.3",
-    "puppeteer": "^24.23.0"
+    "puppeteer-core": "^24.23.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"

--- a/index.html
+++ b/index.html
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 0.5.0003</p>
+      <p>Version 0.5.0004</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/index.html
+++ b/index.html
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 0.5.0004</p>
+      <p>Version 0.5.0005</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/index.html
+++ b/index.html
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 0.5.0005</p>
+      <p>Version 0.5.0006</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/index.html
+++ b/index.html
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 0.5.0006</p>
+      <p>Version 0.5.0007</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/src/js/modules/init/viewBuildPageInit.js
+++ b/src/js/modules/init/viewBuildPageInit.js
@@ -13,11 +13,21 @@ import {
 import { logAnalyticsEvent } from "../analyticsHelper.js";
 import { showToast } from "../toastHandler.js";
 
-function getBuildIdFromPath() {
-  const parts = window.location.pathname.split("/").filter(Boolean);
-  let id = parts[parts.length - 1] || "";
-  if (id.includes("-")) id = id.split("-").pop();
-  return decodeURIComponent(id);
+function getBuildId() {
+  const path = window.location.pathname;
+  const prettyMatch = path.match(/\/build\/[^/]+\/[^/]+\/([^/]+)/);
+  if (prettyMatch?.[1]) {
+    return decodeURIComponent(prettyMatch[1]);
+  }
+
+  const shortMatch = path.match(/\/build\/([^/]+)/);
+  if (shortMatch?.[1]) {
+    return decodeURIComponent(shortMatch[1]);
+  }
+
+  const query = new URLSearchParams(window.location.search);
+  const queryId = query.get("id");
+  return queryId ? decodeURIComponent(queryId) : "";
 }
 
 export function initializeViewBuildPage() {
@@ -29,7 +39,7 @@ export function initializeViewBuildPage() {
 }
 
 async function importBuildHandler() {
-  const maybeTitleOrId = getBuildIdFromPath();
+  const maybeTitleOrId = getBuildId();
 
   if (!maybeTitleOrId) {
     showToast("❌ Build ID or title not found in URL.", "error");

--- a/src/js/modules/viewBuild.js
+++ b/src/js/modules/viewBuild.js
@@ -131,21 +131,25 @@ async function incrementBuildViews(buildId) {
   }
 }
 
-function getBuildIdFromPath() {
-  const searchParams = new URLSearchParams(window.location.search);
-  const queryId = searchParams.get("id");
-  if (queryId) {
-    return decodeURIComponent(queryId);
+function getBuildId() {
+  const path = window.location.pathname;
+  const prettyMatch = path.match(/\/build\/[^/]+\/[^/]+\/([^/]+)/);
+  if (prettyMatch?.[1]) {
+    return decodeURIComponent(prettyMatch[1]);
   }
 
-  const parts = window.location.pathname.split("/").filter(Boolean);
-  let id = parts[parts.length - 1] || "";
-  if (id.includes("-")) id = id.split("-").pop();
-  return decodeURIComponent(id);
+  const shortMatch = path.match(/\/build\/([^/]+)/);
+  if (shortMatch?.[1]) {
+    return decodeURIComponent(shortMatch[1]);
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const queryId = searchParams.get("id");
+  return queryId ? decodeURIComponent(queryId) : "";
 }
 
 async function loadBuild() {
-  const buildId = getBuildIdFromPath();
+  const buildId = getBuildId();
 
   if (!buildId) {
     document.getElementById("buildTitle").innerText = "Build not found.";
@@ -685,7 +689,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       // Don't show the button until we know the status
       importBtn.style.display = "none";
 
-      const buildId = getBuildIdFromPath();
+      const buildId = getBuildId();
       if (!buildId) return;
 
       const buildRef = doc(db, "publishedBuilds", buildId);
@@ -731,7 +735,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // Update vote UI when auth state changes (e.g., after sign-in)
   auth.onAuthStateChanged(() => {
-    const buildId = getBuildIdFromPath();
+    const buildId = getBuildId();
     if (buildId) updateVoteButtonIcons(buildId);
   });
 


### PR DESCRIPTION
## Summary
- refactor the prerendering flow to share Puppeteer capture logic, sanitize meta tags with DOMPurify, and stream bot requests from Storage or on-demand generation
- tighten Firebase Hosting rewrites to only target /build paths for the prerender function
- add the jsdom dependency needed for server-side sanitization and bump the footer version indicator

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10ee52db8832a9125e093eeea4a16