### PR TITLE
Rename comment field to description across app

### DIFF
--- a/archive/eventHandlers.js
+++ b/archive/eventHandlers.js
@@ -756,7 +756,7 @@ function updateDropdownColor() {
 function monitorBuildChanges() {
   const fields = [
     "buildOrderInput",
-    "commentInput",
+    "descriptionInput",
     "videoInput",
     "replayLinkInput",
   ];

--- a/functions/index.js
+++ b/functions/index.js
@@ -284,7 +284,7 @@ function buildMetaStrings(buildData) {
     "Anonymous"
   );
   const sanitizedSubcategory = sanitizeText(buildData.subcategory, "Unknown");
-  const sanitizedComment = sanitizeText(buildData.comment, "");
+  const sanitizedDescription = sanitizeText(buildData.description, "");
   const formattedMatchup = formatMatchupText(sanitizedSubcategory);
 
   const defaultDescription = sanitizeText(
@@ -295,8 +295,8 @@ function buildMetaStrings(buildData) {
     `Build order for ${formattedMatchup} by ${sanitizedPublisher}.`,
     "StarCraft 2 build order"
   );
-  const description = sanitizedComment || defaultDescription;
-  const ogDescription = sanitizedComment || defaultOgDescription;
+  const description = sanitizedDescription || defaultDescription;
+  const ogDescription = sanitizedDescription || defaultOgDescription;
 
   return {
     pageTitle: sanitizeText(
@@ -318,7 +318,7 @@ function buildPrerenderPayload(buildData) {
   );
   const category = sanitizeText(buildData.category, "Unknown");
   const matchup = formatMatchupText(buildData.subcategory);
-  const comment = sanitizeText(buildData.comment, "");
+  const description = sanitizeText(buildData.description, "");
 
   const buildOrderHtml = createBuildOrderHtml(buildData.buildOrder);
   const buildOrderStepCount = Array.isArray(buildData.buildOrder)
@@ -343,7 +343,7 @@ function buildPrerenderPayload(buildData) {
     publisher,
     username: publisher,
     subcategory: matchup,
-    comment,
+    description,
   });
 
   return {
@@ -351,8 +351,8 @@ function buildPrerenderPayload(buildData) {
     publisher,
     category,
     matchup,
-    comment,
-    hasComment: Boolean(comment),
+    description,
+    hasDescription: Boolean(description),
     datePublished,
     buildOrderHtml,
     buildOrderStepCount,
@@ -494,7 +494,7 @@ async function captureBuildHtml(buildId, buildDataFromEvent) {
     matchup: payload.matchup,
     category: payload.category,
     steps: payload.buildOrderStepCount,
-    hasComment: payload.hasComment,
+    hasDescription: payload.hasDescription,
   });
   const browser = await launchBrowser();
   let page;
@@ -549,7 +549,7 @@ async function captureBuildHtml(buildId, buildDataFromEvent) {
       matchup: payload.matchup,
       category: payload.category,
       steps: payload.buildOrderStepCount,
-      hasComment: payload.hasComment,
+      hasDescription: payload.hasDescription,
     });
 
     await page.evaluate(
@@ -590,15 +590,10 @@ async function captureBuildHtml(buildId, buildDataFromEvent) {
 
         setInnerHtml("#buildOrder", data.buildOrderHtml);
 
-        if (data.hasComment) {
-          setTextContent("#buildComment", data.comment);
-          toggleDisplay("#buildComment", true);
-          toggleDisplay("#commentHeader", true);
-        } else {
-          setTextContent("#buildComment", "");
-          toggleDisplay("#buildComment", false);
-          toggleDisplay("#commentHeader", false);
-        }
+        setTextContent(
+          "#buildDescription",
+          data.description || "No description provided."
+        );
 
         const replayWrapper = doc.querySelector("#replayViewWrapper");
         const replayHeader = doc.querySelector("#replayHeader");

--- a/index.html
+++ b/index.html
@@ -326,7 +326,7 @@
 
 
     <div class="main-layout">
-      <!-- Second Row: Map and Comment/Video -->
+      <!-- Second Row: Map and Description/Video -->
 
       <h3 data-section="secondRow" class="toggle-title">
         <span class="arrow"></span> Additional Settings
@@ -353,8 +353,8 @@
           </div>
         </div>
 
-        <!-- RIGHT COLUMN: Comment & Video Container -->
-        <div class="comment-video-container">
+        <!-- RIGHT COLUMN: Description & Video Container -->
+        <div class="description-video-container">
 
           <h3 class="toggle-title">Replay</h3>
 
@@ -379,8 +379,8 @@
           </div>
 
 
-          <h3 class="toggle-title">Comment</h3>
-          <textarea id="commentInput" placeholder="Add a comment..."></textarea>
+          <h3 class="toggle-title">Description</h3>
+          <textarea id="descriptionInput" placeholder="Add a description..."></textarea>
 
           <h3 class="toggle-title">Video</h3>
           <input type="text" id="videoInput" placeholder="Paste YouTube link here..." />
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 0.5.0012</p>
+      <p>Version 0.5.0013</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -495,7 +495,7 @@ textarea {
 }
 
 textarea:focus,
-#commentInput:focus,
+#descriptionInput:focus,
 #videoInput:focus {
   outline: none; /* Removes the outline */
   border: 2px solid #cfcfcf; /* Adds a border for focus instead */
@@ -650,7 +650,7 @@ button:hover {
   animation: highlight 1s ease-in-out 0s infinite alternate;
 }
 
-/* Comment and Video Sections */
+/* Description and Video Sections */
 .hideable-section {
   display: none;
   margin-top: 10px;
@@ -696,8 +696,8 @@ button:hover {
   color: #e0e0e0;
 }
 
-/* Comment and Video Inputs */
-#commentInput,
+/* Description and Video Inputs */
+#descriptionInput,
 #videoInput,
 #replayLinkInput {
   width: 100%;
@@ -2082,7 +2082,7 @@ body.modal-open {
   align-items: center;
 }
 
-/* Second Row: Map and Comment/Video */
+/* Second Row: Map and Description/Video */
 .second-row {
   display: flex;
   gap: 20px; /* Space between the columns */
@@ -2103,16 +2103,16 @@ body.modal-open {
   gap: 8px; /* Space between buttons */
 }
 
-/* Comment and Video Container (Second Column) */
-.comment-video-container {
+/* Description and Video Container (Second Column) */
+.description-video-container {
   flex: 1; /* Takes up the remaining space */
   max-width: 50%; /* Limit width */
   display: flex;
-  flex-direction: column; /* Stack comment and video sections */
-  gap: 8px; /* Space between comment & video */
+  flex-direction: column; /* Stack description and video sections */
+  gap: 8px; /* Space between description & video */
 }
 
-.comment-video-container h3 {
+.description-video-container h3 {
   margin-top: 0px;
 }
 
@@ -4539,7 +4539,7 @@ button.btn-small {
     flex-direction: column; /* Stack elements vertically */
     gap: 20px; /* Add spacing between sections */
   }
-  .comment-video-container {
+  .description-video-container {
     max-width: 100%;
     width: 100%;
   }

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -143,10 +143,10 @@ input[type="text"]:disabled {
   margin-bottom: 30px;
 }
 
-/* Map Section, YouTube Section, Comment Section Common */
+/* Map Section, YouTube Section, Description Section Common */
 .map-section,
 .youtube-section,
-.comment-section {
+.description-section {
   margin-top: 40px;
 }
 
@@ -232,8 +232,8 @@ input[type="text"]:disabled {
   margin: 20px auto 0 auto;
 }
 
-/* Comments Section */
-.comment-display {
+/* Description Section */
+.description-display {
   background: #1a1a1a;
   padding: 20px;
   border-radius: 8px;

--- a/scripts/migrateCommentsToDescriptions.js
+++ b/scripts/migrateCommentsToDescriptions.js
@@ -1,0 +1,14 @@
+// One-time migration script to copy legacy "comment" fields to the new "description" field.
+// Run this in a Firebase Console or Node.js environment that has initialized Firestore.
+export async function migrateCommentsToDescriptions(db, firebase) {
+  const snapshot = await db.collection("communityBuilds").get();
+  snapshot.forEach(async (doc) => {
+    const data = doc.data();
+    if (data.comment) {
+      await doc.ref.update({
+        description: data.comment,
+        comment: firebase.firestore.FieldValue.delete(),
+      });
+    }
+  });
+}

--- a/src/js/modules/buildManagement.js
+++ b/src/js/modules/buildManagement.js
@@ -65,7 +65,7 @@ export async function saveCurrentBuild() {
   const titleInput = document.getElementById("buildOrderTitleInput");
   const titleText = document.getElementById("buildOrderTitleText");
   const categoryDropdown = document.getElementById("buildCategoryDropdown");
-  const commentInput = document.getElementById("commentInput");
+  const descriptionInput = document.getElementById("descriptionInput");
   const videoInput = document.getElementById("videoInput");
   const buildOrderInput = document.getElementById("buildOrderInput");
   const mapImage = document.getElementById("map-preview-image");
@@ -216,7 +216,7 @@ export async function saveCurrentBuild() {
     subcategory: formattedMatchup,
     subcategoryLowercase: formattedMatchup.toLowerCase(),
     timestamp: Date.now(),
-    comment: DOMPurify.sanitize(commentInput?.value.trim() || ""),
+    description: DOMPurify.sanitize(descriptionInput?.value.trim() || ""),
     videoLink: DOMPurify.sanitize(videoInput?.value.trim() || ""),
     replayUrl,
     buildOrder,
@@ -323,7 +323,7 @@ export async function updateCurrentBuild(buildId) {
 
   const db = getFirestore();
   const buildDocRef = doc(db, `users/${user.uid}/builds/${buildId}`);
-  const commentInput = document.getElementById("commentInput");
+  const descriptionInput = document.getElementById("descriptionInput");
   const videoInput = document.getElementById("videoInput");
   const categoryDropdown = document.getElementById("buildCategoryDropdown");
   const buildOrderInput = document.getElementById("buildOrderInput");
@@ -333,7 +333,7 @@ export async function updateCurrentBuild(buildId) {
   const mapMode = modeDropdown ? DOMPurify.sanitize(modeDropdown.value) : "1v1";
 
   const updatedData = {
-    comment: DOMPurify.sanitize(commentInput?.value.trim() || ""),
+    description: DOMPurify.sanitize(descriptionInput?.value.trim() || ""),
     videoLink: DOMPurify.sanitize(videoInput?.value.trim() || ""),
     replayUrl: DOMPurify.sanitize(replayInput?.value.trim() || ""),
     buildOrder: parseBuildOrder(buildOrderInput.value),

--- a/src/js/modules/init/indexPageInit.js
+++ b/src/js/modules/init/indexPageInit.js
@@ -1672,7 +1672,7 @@ export async function initializeIndexPage() {
   function monitorBuildChanges() {
     const fields = [
       "buildOrderInput",
-      "commentInput",
+      "descriptionInput",
       "videoInput",
       "replayLinkInput",
       "buildOrderTitleInput",

--- a/src/js/modules/modal.js
+++ b/src/js/modules/modal.js
@@ -432,10 +432,10 @@ export async function viewBuild(buildId) {
       }`;
     }
 
-    // Comment
-    const commentInput = document.getElementById("commentInput");
-    if (commentInput)
-      commentInput.value = DOMPurify.sanitize(build.comment) || "";
+    // Description
+    const descriptionInput = document.getElementById("descriptionInput");
+    if (descriptionInput)
+      descriptionInput.value = DOMPurify.sanitize(build.description) || "";
 
     // YouTube
     const videoInput = document.getElementById("videoInput");
@@ -1215,7 +1215,7 @@ function loadBuildIntoEditor(build) {
   document.getElementById("buildOrderTitleInput").value = build.title || "";
   document.getElementById("buildCategoryDropdown").value =
     build.subcategory || "";
-  document.getElementById("commentInput").value = build.comment || "";
+  document.getElementById("descriptionInput").value = build.description || "";
   document.getElementById("videoInput").value = build.videoLink || "";
   document.getElementById("buildOrderInput").value = Array.isArray(
     build.buildOrder

--- a/src/js/modules/uiHandlers.js
+++ b/src/js/modules/uiHandlers.js
@@ -89,14 +89,14 @@ export function populateBuildDetails(index) {
     return;
   }
 
-  // Update comment and video input fields
-  const commentInput = document.getElementById("commentInput");
+  // Update description and video input fields
+  const descriptionInput = document.getElementById("descriptionInput");
   const videoInput = document.getElementById("videoInput");
 
-  if (commentInput) {
-    commentInput.value = build.comment || "";
+  if (descriptionInput) {
+    descriptionInput.value = build.description || "";
   } else {
-    console.warn("commentInput not found!");
+    console.warn("descriptionInput not found!");
   }
 
   if (videoInput) {
@@ -139,7 +139,9 @@ export function populateBuildDetails(index) {
 
   buildDetailsContainer.innerHTML = `
   <h3>${DOMPurify.sanitize(build.title)}</h3>
-  <p>${DOMPurify.sanitize(build.comment || "No comments provided.")}</p>
+  <p>${DOMPurify.sanitize(
+    build.description || "No description provided."
+  )}</p>
   <pre>${build.buildOrder
     .map(
       (step) =>

--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -46,10 +46,10 @@ export function resetBuildInputs() {
     categoryDropdown.style.color = ""; // 🔁 Reset custom color
   }
 
-  // ✅ Reset Comment and Video Inputs
-  const commentInput = document.getElementById("commentInput");
+  // ✅ Reset Description and Video Inputs
+  const descriptionInput = document.getElementById("descriptionInput");
   const videoInput = document.getElementById("videoInput");
-  if (commentInput) commentInput.value = "";
+  if (descriptionInput) descriptionInput.value = "";
   if (videoInput) videoInput.value = "";
 
   // ✅ Reset Build Order Input

--- a/src/js/modules/viewBuild.js
+++ b/src/js/modules/viewBuild.js
@@ -266,19 +266,10 @@ async function loadBuild() {
       }
     }
 
-    // Set comment
-    const commentElement = document.getElementById("buildComment");
-    const commentHeader = document.getElementById("commentHeader");
-    if (commentElement && commentHeader) {
-      if (build.comment && build.comment.trim() !== "") {
-        commentElement.innerText = build.comment;
-        commentElement.style.display = "block";
-        commentHeader.style.display = "block";
-      } else {
-        commentElement.style.display = "none";
-        commentHeader.style.display = "none";
-      }
-    }
+    // Set description
+    const descEl = document.getElementById("buildDescription");
+    if (descEl)
+      descEl.innerText = build.description || "No description provided.";
 
     // Set YouTube link
     const youtubeEmbed = document.getElementById("videoIframe");
@@ -454,8 +445,6 @@ async function loadBuild() {
     );
     const mainLayout = document.querySelector(".main-layout");
     if (additionalHeader || mainLayout) {
-      const commentVisible =
-        commentElement && commentElement.style.display !== "none";
       const videoVisible =
         youtubeEmbed && youtubeEmbed.style.display !== "none";
       const mapVisible =
@@ -463,8 +452,7 @@ async function loadBuild() {
       const replayVisible =
         replayWrapper && replayWrapper.style.display !== "none";
 
-      const anyVisible =
-        commentVisible || videoVisible || mapVisible || replayVisible;
+      const anyVisible = videoVisible || mapVisible || replayVisible;
 
       const secondRow = document.getElementById("secondRow");
       const secondRowHeader = document.querySelector(

--- a/viewBuild.html
+++ b/viewBuild.html
@@ -155,9 +155,14 @@
       <!-- Build steps are dynamically inserted here -->
     </div>
 
+    <div class="build-description-container">
+      <h3>Description</h3>
+      <p id="buildDescription">No description provided.</p>
+    </div>
+
     <!-- Second Row Layout -->
     <div class="main-layout">
-      <!-- Second Row: Map and Comment/Video -->
+      <!-- Second Row: Map and Description/Video -->
 
       <h3 id="additionalSettingsHeader" data-section="secondRow" class="toggle-title" style="display: none">
         <span class="arrow"></span> Additional Settings
@@ -178,18 +183,14 @@
           </div>
         </div>
 
-        <!-- RIGHT COLUMN: Comment & Video Container -->
-        <div class="comment-video-container">
+        <!-- RIGHT COLUMN: Description & Video Container -->
+        <div class="description-video-container">
           <h3 id="replayHeader" class="toggle-title" style="display: none">Replay</h3>
           <div id="replayViewWrapper" style="display: none;">
             <a id="replayDownloadBtn" href="#" target="_blank" class="download-replay-link">
               Download Replay on Drop.sc
             </a>
           </div>
-
-          <h3 id="commentHeader" class="toggle-title" style="display: none">Comment</h3>
-          <p id="buildComment" class="comment-display" style="display: none"></p>
-
           <h3 id="videoHeader" class="toggle-title" style="display: none">Video</h3>
           <iframe id="videoIframe" style="display: none;" width="560" height="315" frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## Summary
- rename all build form and data references from comment to description, including sanitized inputs and Firestore payloads
- surface the description on the build detail page with a dedicated section and updated styling
- add a one-off Firestore migration script to copy legacy comment values into the new description field

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e290f31bf8832a8f8f3a63baa4a336