### PR TITLE
Add real-time comments to View Build page

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,51 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function adminEmailList() {
+      return exists(/databases/$(database)/documents/appConfig/admins)
+        && get(/databases/$(database)/documents/appConfig/admins).data.emails is list
+        ? get(/databases/$(database)/documents/appConfig/admins).data.emails
+        : [];
+    }
+
+    function isAdmin() {
+      return isSignedIn()
+        && request.auth.token.email is string
+        && adminEmailList().hasAny([request.auth.token.email]);
+    }
+
+    match /publishedBuilds/{buildId} {
+      allow read: if true;
+
+      match /comments/{commentId} {
+        allow read: if true;
+
+        allow create: if isSignedIn()
+          && request.resource.data.keys().hasOnly([
+            "userId",
+            "username",
+            "photoURL",
+            "text",
+            "timestamp"
+          ])
+          && request.resource.data.userId == request.auth.uid
+          && request.resource.data.username is string
+          && request.resource.data.username.size() >= 2
+          && request.resource.data.text is string
+          && request.resource.data.text.size() >= 2
+          && request.resource.data.text.size() <= 1200
+          && request.resource.data.photoURL is string
+          && request.resource.data.timestamp == request.time;
+
+        allow delete: if isSignedIn()
+          && (request.auth.uid == resource.data.userId || isAdmin());
+
+        allow update: if false;
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -860,7 +860,7 @@
       <a href="#" id="supportersLink">Support</a>
     </div>
     <div class="footer-right" id="site-info">
-      <p>Version 0.5.0017</p>
+      <p>Version 0.5.0018</p>
     </div>
 
     <div id="cookieBanner" class="cookie-banner">

--- a/public/css/viewBuild.css
+++ b/public/css/viewBuild.css
@@ -140,6 +140,223 @@ input[type="text"]:disabled {
   line-height: 1.5;
 }
 
+.comment-section {
+  margin-top: 24px;
+  padding: 20px;
+  background: #141414;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.comment-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.comment-section-header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #ffffff;
+}
+
+.comment-count {
+  margin-left: 8px;
+  font-size: 0.9rem;
+  color: #9e9e9e;
+  font-weight: 500;
+}
+
+.comment-signin-btn {
+  border: 1px solid #00bcd4;
+  background: transparent;
+  color: #00bcd4;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.comment-signin-btn:hover {
+  background: #00bcd4;
+  color: #121212;
+}
+
+.comments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.comment-card {
+  display: flex;
+  gap: 12px;
+  padding: 14px;
+  background: #1e1e1e;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.comment-avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.comment-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.comment-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.comment-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.comment-username {
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.comment-timestamp {
+  font-size: 0.75rem;
+  color: #9e9e9e;
+}
+
+.comment-text {
+  color: #dddddd;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.comment-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.comment-delete-btn {
+  background: transparent;
+  border: none;
+  color: #9e9e9e;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.comment-delete-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ff867c;
+}
+
+.comment-delete-btn img {
+  width: 18px;
+  height: 18px;
+  pointer-events: none;
+  filter: invert(70%);
+}
+
+.comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.comment-form textarea {
+  min-height: 110px;
+  padding: 12px;
+  background: #1e1e1e;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  color: #ffffff;
+  resize: vertical;
+  font-size: 0.95rem;
+}
+
+.comment-form textarea:focus {
+  outline: none;
+  border-color: #00bcd4;
+  box-shadow: 0 0 0 1px rgba(0, 188, 212, 0.4);
+}
+
+.comment-form button {
+  align-self: flex-end;
+  background: #00bcd4;
+  color: #121212;
+  border: none;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.comment-form button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 12px rgba(0, 188, 212, 0.3);
+}
+
+.comment-form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.comment-empty,
+.comment-error,
+.comment-loading {
+  color: #9e9e9e;
+  font-size: 0.9rem;
+}
+
+.comment-error {
+  color: #ff867c;
+}
+
+.comment-signin-prompt {
+  margin: 0;
+  color: #b0b0b0;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+  .comment-section {
+    padding: 16px;
+  }
+
+  .comment-card {
+    flex-direction: column;
+  }
+
+  .comment-avatar {
+    width: 36px;
+    height: 36px;
+  }
+
+  .comment-form button {
+    width: 100%;
+    align-self: stretch;
+  }
+}
+
 /* Scrollbar for Build Order */
 .build-order-container::-webkit-scrollbar {
   width: 8px;

--- a/viewBuild.html
+++ b/viewBuild.html
@@ -161,6 +161,21 @@
       <p id="buildDescription" class="description-display"></p>
     </div>
 
+    <div class="comment-section">
+      <div class="comment-section-header">
+        <h3>Comments <span id="commentsCount" class="comment-count">0 comments</span></h3>
+        <button id="commentSignInBtn" class="comment-signin-btn" style="display: none;">Sign in to comment</button>
+      </div>
+      <div id="commentsList" class="comments-list"></div>
+      <p id="commentSignInPrompt" class="comment-signin-prompt" style="display: none;">
+        Sign in to share your thoughts.
+      </p>
+      <div id="commentForm" class="comment-form" style="display: none;">
+        <textarea id="newCommentInput" placeholder="Write a comment..."></textarea>
+        <button id="postCommentBtn">Post</button>
+      </div>
+    </div>
+
     <!-- Second Row Layout -->
     <div class="main-layout">
       <!-- Second Row: Map and Description/Video -->


### PR DESCRIPTION
## Summary
- add a comment section to the view build layout with sign-in prompts and posting controls
- implement real-time comment loading, creation, and deletion logic with sanitization and role checks
- style the new comment UI, add screenshot assets, and define Firestore rules plus version bump

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e2b8d94608832aa2b6bdc56575211d